### PR TITLE
Fix broken prisma-client import on windows

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -189,7 +189,7 @@ export default class Transformer {
       prismaClientPath = path.relative(
         path.join(Transformer.outputPath, 'schemas', 'objects'),
         prismaClientPath,
-      );
+      ).split(path.sep).join(path.posix.sep);
     }
     return `import type { Prisma } from '${prismaClientPath}';\n\n`;
   }


### PR DESCRIPTION
### Description
Making sure relative path uses POSIX seperators
> This PR fixes the issue where relative paths generated for prisma-client imports can include a backslash ```\``` which is being ignored as a character and thus resulting in an unusable import. The change makes sure that relative path uses POSIX separators instead of Windows separators by removing the existing separators and replacing them with POSIX separators 


### References

> Issue: #9 

Also my first OSS PR, please give feedback if anything is missing/incomplete, thanks! :)
