### PR TITLE
Added support for BigInt

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ model Post {
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
+  likes     BigInt
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.2.0",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "gen-example": "tsc && npx prisma generate",
-    "package:publish": "./package.sh && cd package && npm publish"
+    "package:publish": "./package.sh && cd package && npm publish",
+    "postinstall": "tsc"
   },
   "author": {
     "name": "Omar Dulaimi",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,4 +29,5 @@ model Post {
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
+  likes     BigInt
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -107,7 +107,7 @@ export default class Transformer {
         inputType.type === 'Decimal'
       ) {
         result.push(this.wrapWithZodValidators('z.number()', field, inputType));
-      } else if (inputType.type) {
+      } else if (inputType.type === 'BigInt') {
         result.push(
           this.wrapWithZodValidators('z.bigint()', field, inputType),
         );

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -111,7 +111,7 @@ export default class Transformer {
         result.push(
           this.wrapWithZodValidators('z.bigint()', field, inputType),
         );
-      }else if (inputType.type === 'Boolean') {
+      } else if (inputType.type === 'Boolean') {
         result.push(
           this.wrapWithZodValidators('z.boolean()', field, inputType),
         );

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -107,7 +107,11 @@ export default class Transformer {
         inputType.type === 'Decimal'
       ) {
         result.push(this.wrapWithZodValidators('z.number()', field, inputType));
-      } else if (inputType.type === 'Boolean') {
+      } else if (inputType.type) {
+        result.push(
+          this.wrapWithZodValidators('z.bigint()', field, inputType),
+        );
+      }else if (inputType.type === 'Boolean') {
         result.push(
           this.wrapWithZodValidators('z.boolean()', field, inputType),
         );


### PR DESCRIPTION
### Description

Currently Prisma's `BigInt` is not parsed. For instance if we extend the `Post` model with likes:

```prisma
model Post {
  id        Int      @id @default(autoincrement())
  createdAt DateTime @default(now())
  updatedAt DateTime @updatedAt
  title     String
  content   String?
  published Boolean  @default(false)
  viewCount Int      @default(0)
  author    User?    @relation(fields: [authorId], references: [id])
  authorId  Int?
  likes     BigInt
}
```

One of the results is:

```typescript
const Schema: z.ZodType<Prisma.PostCreateInput> = z
  .object({
    createdAt: z.bigint().optional(),
    updatedAt: z.bigint().optional(),
    title: z.string(),
    content: z.union([z.string(), z.bigint()]).optional().nullable(),
    published: z.bigint().optional(),
    viewCount: z.number().optional(),
    author: z.bigint().optional(),
  })
  .strict();

export const PostCreateInputObjectSchema = Schema;
```

With the proposed fix, the schema now includes `likes`:

```typescript
const Schema: z.ZodType<Prisma.PostCreateInput> = z
  .object({
   // ...
    author: z.bigint().optional(),
    likes: z.bigint(),
  })
  .strict();
```

To test the fix, simply run `npm run gen-example` and inspect the file `prisma/generated/schemas/objects/PostCreateInput.schema.ts`.
