### PR TITLE
strict() on zod objects within union

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -278,7 +278,7 @@ export default class Transformer {
       return this.wrapWithZodObject(fields) + '.strict()';
     }
 
-    const wrapped = fields.map((field) => this.wrapWithZodObject(field));
+    const wrapped = fields.map((field) => this.wrapWithZodObject(field) + '.strict()');
 
     return this.wrapWithZodOUnion(wrapped);
   }


### PR DESCRIPTION
### Description

Adding '.strict()' to the Zod objects within a union type, which appears to keep Zod from stripping properties via non-matching elements of the union.

Not sure if there are reasons to avoid `strict` here. If so, this PR may not be an appropriate solution for the problem. Additionally, this seems like questionable behavior on Zod's part and thus the "real fix" may be within Zod.

### References

Fixes https://github.com/omar-dulaimi/prisma-zod-generator/issues/16
