### PR TITLE
Refactor + select support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ app.post('/blog', async (req, res, next) => {
 
 ## Additional Options
 
-| Option   |  Description                                   | Type     |  Default      |
-| -------- | ---------------------------------------------- | -------- | ------------- |
-| `output` | Output directory for the generated zod schemas | `string` | `./generated` |
+| Option             |  Description                                                             | Type      |  Default      |
+| ------------------ | ------------------------------------------------------------------------ | --------- | ------------- |
+| `output`           | Output directory for the generated zod schemas                           | `string`  | `./generated` |
+| `isGenerateSelect` | Enables the generation of Select related schemas and the select property | `boolean` | `false`       |
 
 Use additional options in the `schema.prisma`
 
@@ -118,5 +119,6 @@ Use additional options in the `schema.prisma`
 generator zod {
   provider   = "prisma-zod-generator"
   output     = "./generated-zod-schemas"
+  isGenerate = true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ Use additional options in the `schema.prisma`
 generator zod {
   provider   = "prisma-zod-generator"
   output     = "./generated-zod-schemas"
-  isGenerate = true
+  isGenerateSelect = true
 }
 ```

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,8 @@ datasource db {
 
 generator zod {
   provider = "node ./lib/generator.js"
-  output   = "./generated"
+  output   = "./generated"  
+  isGenerateSelect = true
 }
 
 model User {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,2 +1,0 @@
-export const isMongodbRawOp = (name: string) =>
-  /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,0 @@
-export const isMongodbRawOp = (name: string) =>
-  /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);
-
-export const isAggregateOutputType = (name: string) =>
-  /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);

--- a/src/helpers/aggregate-helpers.ts
+++ b/src/helpers/aggregate-helpers.ts
@@ -1,0 +1,32 @@
+import { DMMF } from '@prisma/generator-helper';
+
+const isAggregateOutputType = (name: string) =>
+  /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);
+
+export function addMissingInputObjectTypesForAggregate(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+) {
+  const aggregateOutputTypes = outputObjectTypes.filter(({ name }) =>
+    isAggregateOutputType(name),
+  );
+  for (const aggregateOutputType of aggregateOutputTypes) {
+    const name = aggregateOutputType.name.replace(/(?:OutputType|Output)$/, '');
+    inputObjectTypes.push({
+      constraints: { maxNumFields: null, minNumFields: null },
+      name: `${name}Input`,
+      fields: aggregateOutputType.fields.map((field) => ({
+        name: field.name,
+        isNullable: false,
+        isRequired: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: 'True',
+            location: 'scalar',
+          },
+        ],
+      })),
+    });
+  }
+}

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,0 +1,228 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypes(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+  models: DMMF.Model[],
+) {
+  addMissingInputObjectTypesForSelect(
+    inputObjectTypes,
+    outputObjectTypes,
+    models,
+  );
+}
+
+function addMissingInputObjectTypesForSelect(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+  models: DMMF.Model[],
+) {
+  // generate input object types necessary to support ModelSelect._count
+  const modelCountOutputTypes = getModelCountOutputTypes(outputObjectTypes);
+  const modelCountOutputTypeSelectInputObjectTypes =
+    generateModelCountOutputTypeSelectInputObjectTypes(modelCountOutputTypes);
+  const modelCountOutputTypeArgsInputObjectTypes =
+    generateModelCountOutputTypeArgsInputObjectTypes(modelCountOutputTypes);
+
+  // generate input object types necessary to support ModelSelect with relation support
+  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(models);
+  const modelSelectInputObjectTypes =
+    generateModelSelectInputObjectTypes(models);
+
+  const generatedInputObjectTypes = [
+    modelCountOutputTypeSelectInputObjectTypes,
+    modelCountOutputTypeArgsInputObjectTypes,
+    modelArgsInputObjectTypes,
+    modelSelectInputObjectTypes,
+  ].flat();
+
+  for (const inputObjectType of generatedInputObjectTypes) {
+    inputObjectTypes.push(inputObjectType);
+  }
+}
+
+function getModelCountOutputTypes(outputObjectTypes: DMMF.OutputType[]) {
+  return outputObjectTypes.filter(({ name }) =>
+    name.includes('CountOutputType'),
+  );
+}
+
+function generateModelCountOutputTypeSelectInputObjectTypes(
+  modelCountOutputTypes: DMMF.OutputType[],
+) {
+  const modelCountOutputTypeSelectInputObjectTypes: DMMF.InputType[] = [];
+  for (const modelCountOutputType of modelCountOutputTypes) {
+    const {
+      name: modelCountOutputTypeName,
+      fields: modelCountOutputTypeFields,
+    } = modelCountOutputType;
+    const modelCountOutputTypeSelectInputObjectType: DMMF.InputType = {
+      name: `${modelCountOutputTypeName}Select`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields: modelCountOutputTypeFields.map(({ name }) => ({
+        name,
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `Boolean`,
+            location: 'scalar',
+          },
+        ],
+      })),
+    };
+    modelCountOutputTypeSelectInputObjectTypes.push(
+      modelCountOutputTypeSelectInputObjectType,
+    );
+  }
+  return modelCountOutputTypeSelectInputObjectTypes;
+}
+
+function generateModelCountOutputTypeArgsInputObjectTypes(
+  modelCountOutputTypes: DMMF.OutputType[],
+) {
+  const modelCountOutputTypeArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const modelCountOutputType of modelCountOutputTypes) {
+    const { name: modelCountOutputTypeName } = modelCountOutputType;
+    const modelCountOutputTypeArgsInputObjectType: DMMF.InputType = {
+      name: `${modelCountOutputTypeName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields: [
+        {
+          name: 'select',
+          isRequired: false,
+          isNullable: false,
+          inputTypes: [
+            {
+              isList: false,
+              type: `${modelCountOutputTypeName}Select`,
+              location: 'inputObjectTypes',
+              namespace: 'prisma',
+            },
+          ],
+        },
+      ],
+    };
+    modelCountOutputTypeArgsInputObjectTypes.push(
+      modelCountOutputTypeArgsInputObjectType,
+    );
+  }
+  return modelCountOutputTypeArgsInputObjectTypes;
+}
+
+function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
+  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    const selectField: DMMF.SchemaArg = {
+      name: 'select',
+      isRequired: false,
+      isNullable: false,
+      inputTypes: [
+        {
+          isList: false,
+          type: `${modelName}Select`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        },
+      ],
+    };
+    fields.push(selectField);
+
+    /** @todo add include field in a future pull request */
+
+    const modelArgsInputObjectType: DMMF.InputType = {
+      name: `${modelName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
+  }
+  return modelArgsInputObjectTypes;
+}
+
+function generateModelSelectInputObjectTypes(models: DMMF.Model[]) {
+  const modelSelectInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName, fields: modelFields } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    let hasManyRelation = false;
+
+    for (const modelField of modelFields) {
+      const {
+        name: modelFieldName,
+        kind,
+        relationName,
+        isList,
+        type,
+      } = modelField;
+
+      const isRelationField = kind === 'object' && !!relationName;
+      if (isRelationField && isList) {
+        hasManyRelation = true;
+      }
+
+      const field: DMMF.SchemaArg = {
+        name: modelFieldName,
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [{ isList: false, type: 'Boolean', location: 'scalar' }],
+      };
+
+      if (isRelationField) {
+        let schemaArgInputType: DMMF.SchemaArgInputType = {
+          isList: false,
+          type: isList ? `${type}FindManyArgs` : `${type}Args`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        };
+        field.inputTypes.push(schemaArgInputType);
+      }
+
+      fields.push(field);
+    }
+
+    const shouldAddCountField = hasManyRelation;
+    if (shouldAddCountField) {
+      const _countField: DMMF.SchemaArg = {
+        name: '_count',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          { isList: false, type: 'Boolean', location: 'scalar' },
+          {
+            isList: false,
+            type: `${modelName}CountOutputTypeArgs`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(_countField);
+    }
+
+    const modelSelectInputObjectType: DMMF.InputType = {
+      name: `${modelName}Select`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelSelectInputObjectTypes.push(modelSelectInputObjectType);
+  }
+  return modelSelectInputObjectTypes;
+}

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,228 +1,27 @@
-import { DMMF } from '@prisma/generator-helper';
+import { DMMF, ConnectorType } from '@prisma/generator-helper';
+import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
+import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
+import { addMissingInputObjectTypesForSelect } from './select-helpers';
 
 export function addMissingInputObjectTypes(
   inputObjectTypes: DMMF.InputType[],
   outputObjectTypes: DMMF.OutputType[],
   models: DMMF.Model[],
+  modelOperations: DMMF.ModelMapping[],
+  dataSourceProvider: ConnectorType,
 ) {
+  // TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
+  if (dataSourceProvider === 'mongodb') {
+    addMissingInputObjectTypesForMongoDbRawOpsAndQueries(
+      modelOperations,
+      outputObjectTypes,
+      inputObjectTypes,
+    );
+  }
+  addMissingInputObjectTypesForAggregate(inputObjectTypes, outputObjectTypes);
   addMissingInputObjectTypesForSelect(
     inputObjectTypes,
     outputObjectTypes,
     models,
   );
-}
-
-function addMissingInputObjectTypesForSelect(
-  inputObjectTypes: DMMF.InputType[],
-  outputObjectTypes: DMMF.OutputType[],
-  models: DMMF.Model[],
-) {
-  // generate input object types necessary to support ModelSelect._count
-  const modelCountOutputTypes = getModelCountOutputTypes(outputObjectTypes);
-  const modelCountOutputTypeSelectInputObjectTypes =
-    generateModelCountOutputTypeSelectInputObjectTypes(modelCountOutputTypes);
-  const modelCountOutputTypeArgsInputObjectTypes =
-    generateModelCountOutputTypeArgsInputObjectTypes(modelCountOutputTypes);
-
-  // generate input object types necessary to support ModelSelect with relation support
-  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(models);
-  const modelSelectInputObjectTypes =
-    generateModelSelectInputObjectTypes(models);
-
-  const generatedInputObjectTypes = [
-    modelCountOutputTypeSelectInputObjectTypes,
-    modelCountOutputTypeArgsInputObjectTypes,
-    modelArgsInputObjectTypes,
-    modelSelectInputObjectTypes,
-  ].flat();
-
-  for (const inputObjectType of generatedInputObjectTypes) {
-    inputObjectTypes.push(inputObjectType);
-  }
-}
-
-function getModelCountOutputTypes(outputObjectTypes: DMMF.OutputType[]) {
-  return outputObjectTypes.filter(({ name }) =>
-    name.includes('CountOutputType'),
-  );
-}
-
-function generateModelCountOutputTypeSelectInputObjectTypes(
-  modelCountOutputTypes: DMMF.OutputType[],
-) {
-  const modelCountOutputTypeSelectInputObjectTypes: DMMF.InputType[] = [];
-  for (const modelCountOutputType of modelCountOutputTypes) {
-    const {
-      name: modelCountOutputTypeName,
-      fields: modelCountOutputTypeFields,
-    } = modelCountOutputType;
-    const modelCountOutputTypeSelectInputObjectType: DMMF.InputType = {
-      name: `${modelCountOutputTypeName}Select`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields: modelCountOutputTypeFields.map(({ name }) => ({
-        name,
-        isRequired: false,
-        isNullable: false,
-        inputTypes: [
-          {
-            isList: false,
-            type: `Boolean`,
-            location: 'scalar',
-          },
-        ],
-      })),
-    };
-    modelCountOutputTypeSelectInputObjectTypes.push(
-      modelCountOutputTypeSelectInputObjectType,
-    );
-  }
-  return modelCountOutputTypeSelectInputObjectTypes;
-}
-
-function generateModelCountOutputTypeArgsInputObjectTypes(
-  modelCountOutputTypes: DMMF.OutputType[],
-) {
-  const modelCountOutputTypeArgsInputObjectTypes: DMMF.InputType[] = [];
-  for (const modelCountOutputType of modelCountOutputTypes) {
-    const { name: modelCountOutputTypeName } = modelCountOutputType;
-    const modelCountOutputTypeArgsInputObjectType: DMMF.InputType = {
-      name: `${modelCountOutputTypeName}Args`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields: [
-        {
-          name: 'select',
-          isRequired: false,
-          isNullable: false,
-          inputTypes: [
-            {
-              isList: false,
-              type: `${modelCountOutputTypeName}Select`,
-              location: 'inputObjectTypes',
-              namespace: 'prisma',
-            },
-          ],
-        },
-      ],
-    };
-    modelCountOutputTypeArgsInputObjectTypes.push(
-      modelCountOutputTypeArgsInputObjectType,
-    );
-  }
-  return modelCountOutputTypeArgsInputObjectTypes;
-}
-
-function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
-  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
-  for (const model of models) {
-    const { name: modelName } = model;
-    const fields: DMMF.SchemaArg[] = [];
-
-    const selectField: DMMF.SchemaArg = {
-      name: 'select',
-      isRequired: false,
-      isNullable: false,
-      inputTypes: [
-        {
-          isList: false,
-          type: `${modelName}Select`,
-          location: 'inputObjectTypes',
-          namespace: 'prisma',
-        },
-      ],
-    };
-    fields.push(selectField);
-
-    /** @todo add include field in a future pull request */
-
-    const modelArgsInputObjectType: DMMF.InputType = {
-      name: `${modelName}Args`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields,
-    };
-    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
-  }
-  return modelArgsInputObjectTypes;
-}
-
-function generateModelSelectInputObjectTypes(models: DMMF.Model[]) {
-  const modelSelectInputObjectTypes: DMMF.InputType[] = [];
-  for (const model of models) {
-    const { name: modelName, fields: modelFields } = model;
-    const fields: DMMF.SchemaArg[] = [];
-
-    let hasManyRelation = false;
-
-    for (const modelField of modelFields) {
-      const {
-        name: modelFieldName,
-        kind,
-        relationName,
-        isList,
-        type,
-      } = modelField;
-
-      const isRelationField = kind === 'object' && !!relationName;
-      if (isRelationField && isList) {
-        hasManyRelation = true;
-      }
-
-      const field: DMMF.SchemaArg = {
-        name: modelFieldName,
-        isRequired: false,
-        isNullable: false,
-        inputTypes: [{ isList: false, type: 'Boolean', location: 'scalar' }],
-      };
-
-      if (isRelationField) {
-        let schemaArgInputType: DMMF.SchemaArgInputType = {
-          isList: false,
-          type: isList ? `${type}FindManyArgs` : `${type}Args`,
-          location: 'inputObjectTypes',
-          namespace: 'prisma',
-        };
-        field.inputTypes.push(schemaArgInputType);
-      }
-
-      fields.push(field);
-    }
-
-    const shouldAddCountField = hasManyRelation;
-    if (shouldAddCountField) {
-      const _countField: DMMF.SchemaArg = {
-        name: '_count',
-        isRequired: false,
-        isNullable: false,
-        inputTypes: [
-          { isList: false, type: 'Boolean', location: 'scalar' },
-          {
-            isList: false,
-            type: `${modelName}CountOutputTypeArgs`,
-            location: 'inputObjectTypes',
-            namespace: 'prisma',
-          },
-        ],
-      };
-      fields.push(_countField);
-    }
-
-    const modelSelectInputObjectType: DMMF.InputType = {
-      name: `${modelName}Select`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields,
-    };
-    modelSelectInputObjectTypes.push(modelSelectInputObjectType);
-  }
-  return modelSelectInputObjectTypes;
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,7 +1,12 @@
-import { DMMF, ConnectorType } from '@prisma/generator-helper';
+import { DMMF, ConnectorType, Dictionary } from '@prisma/generator-helper';
+import Transformer from '../transformer';
 import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
 import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
 import { addMissingInputObjectTypesForSelect } from './select-helpers';
+
+interface AddMissingInputObjectTypeOptions {
+  isGenerateSelect: boolean;
+}
 
 export function addMissingInputObjectTypes(
   inputObjectTypes: DMMF.InputType[],
@@ -9,6 +14,7 @@ export function addMissingInputObjectTypes(
   models: DMMF.Model[],
   modelOperations: DMMF.ModelMapping[],
   dataSourceProvider: ConnectorType,
+  options: AddMissingInputObjectTypeOptions,
 ) {
   // TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
   if (dataSourceProvider === 'mongodb') {
@@ -19,9 +25,20 @@ export function addMissingInputObjectTypes(
     );
   }
   addMissingInputObjectTypesForAggregate(inputObjectTypes, outputObjectTypes);
-  addMissingInputObjectTypesForSelect(
-    inputObjectTypes,
-    outputObjectTypes,
-    models,
-  );
+  if (options.isGenerateSelect) {
+    addMissingInputObjectTypesForSelect(
+      inputObjectTypes,
+      outputObjectTypes,
+      models,
+    );
+    Transformer.setIsGenerateSelect(true);
+  }
+}
+
+export function resolveAddMissingInputObjectTypeOptions(
+  generatorConfigOptions: Dictionary<string>,
+): AddMissingInputObjectTypeOptions {
+  return {
+    isGenerateSelect: generatorConfigOptions.isGenerateSelect === 'true',
+  };
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,2 @@
-// export * from './helpers';
+export * from './helpers';
 export * from './mongodb-helpers';

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,2 @@
+// export * from './helpers';
+export * from './mongodb-helpers';

--- a/src/helpers/mongodb-helpers.ts
+++ b/src/helpers/mongodb-helpers.ts
@@ -1,0 +1,84 @@
+import { DMMF } from '@prisma/generator-helper';
+import Transformer from '../transformer';
+
+export function handleMongoDbRawOperationsAndQueries(
+  modelOperations: DMMF.ModelMapping[],
+  outputObjectTypes: DMMF.OutputType[],
+  inputObjectTypes: DMMF.InputType[],
+) {
+  const rawOpsMap = resolveMongoDbRawOperations(modelOperations);
+  Transformer.rawOpsMap = rawOpsMap ?? {};
+
+  const mongoDbRawQueryInputObjectTypes =
+    resolveMongoDbRawQueryInputObjectTypes(outputObjectTypes);
+  for (const mongoDbRawQueryInputType of mongoDbRawQueryInputObjectTypes) {
+    inputObjectTypes.push(mongoDbRawQueryInputType);
+  }
+}
+
+function resolveMongoDbRawOperations(modelOperations: DMMF.ModelMapping[]) {
+  const rawOpsMap: { [name: string]: string } = {};
+  const rawOpsNames = [
+    ...new Set(
+      modelOperations.reduce<string[]>((result, current) => {
+        const keys = Object.keys(current);
+        keys?.forEach((key) => {
+          if (key.includes('Raw')) {
+            result.push(key);
+          }
+        });
+        return result;
+      }, []),
+    ),
+  ];
+
+  const modelNames = modelOperations.map((item) => item.model);
+
+  rawOpsNames.forEach((opName) => {
+    modelNames.forEach((modelName) => {
+      const isFind = opName === 'findRaw';
+      const opWithModel = `${opName.replace('Raw', '')}${modelName}Raw`;
+      rawOpsMap[opWithModel] = isFind
+        ? `${modelName}FindRawArgs`
+        : `${modelName}AggregateRawArgs`;
+    });
+  });
+
+  return rawOpsMap;
+}
+
+function resolveMongoDbRawQueryInputObjectTypes(
+  outputObjectTypes: DMMF.OutputType[],
+) {
+  const mongoDbRawQueries = getMongoDbRawQueries(outputObjectTypes);
+  const mongoDbRawQueryInputObjectTypes = mongoDbRawQueries.map((item) => ({
+    name: item.name,
+    constraints: {
+      maxNumFields: null,
+      minNumFields: null,
+    },
+    fields: item.args.map((arg) => ({
+      name: arg.name,
+      isRequired: arg.isRequired,
+      isNullable: arg.isNullable,
+      inputTypes: arg.inputTypes,
+    })),
+  }));
+  return mongoDbRawQueryInputObjectTypes;
+}
+
+function getMongoDbRawQueries(outputObjectTypes: DMMF.OutputType[]) {
+  const queryOutputTypes = outputObjectTypes.filter(
+    (item) => item.name === 'Query',
+  );
+
+  const mongodbRawQueries =
+    queryOutputTypes?.[0].fields.filter((field) =>
+      field.name.includes('Raw'),
+    ) ?? [];
+
+  return mongodbRawQueries;
+}
+
+export const isMongodbRawOp = (name: string) =>
+  /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);

--- a/src/helpers/mongodb-helpers.ts
+++ b/src/helpers/mongodb-helpers.ts
@@ -1,7 +1,7 @@
 import { DMMF } from '@prisma/generator-helper';
 import Transformer from '../transformer';
 
-export function handleMongoDbRawOperationsAndQueries(
+export function addMissingInputObjectTypesForMongoDbRawOpsAndQueries(
   modelOperations: DMMF.ModelMapping[],
   outputObjectTypes: DMMF.OutputType[],
   inputObjectTypes: DMMF.InputType[],

--- a/src/helpers/select-helpers.ts
+++ b/src/helpers/select-helpers.ts
@@ -1,0 +1,216 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypesForSelect(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+  models: DMMF.Model[],
+) {
+  // generate input object types necessary to support ModelSelect._count
+  const modelCountOutputTypes = getModelCountOutputTypes(outputObjectTypes);
+  const modelCountOutputTypeSelectInputObjectTypes =
+    generateModelCountOutputTypeSelectInputObjectTypes(modelCountOutputTypes);
+  const modelCountOutputTypeArgsInputObjectTypes =
+    generateModelCountOutputTypeArgsInputObjectTypes(modelCountOutputTypes);
+
+  // generate input object types necessary to support ModelSelect with relation support
+  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(models);
+  const modelSelectInputObjectTypes =
+    generateModelSelectInputObjectTypes(models);
+
+  const generatedInputObjectTypes = [
+    modelCountOutputTypeSelectInputObjectTypes,
+    modelCountOutputTypeArgsInputObjectTypes,
+    modelArgsInputObjectTypes,
+    modelSelectInputObjectTypes,
+  ].flat();
+
+  for (const inputObjectType of generatedInputObjectTypes) {
+    inputObjectTypes.push(inputObjectType);
+  }
+}
+
+function getModelCountOutputTypes(outputObjectTypes: DMMF.OutputType[]) {
+  return outputObjectTypes.filter(({ name }) =>
+    name.includes('CountOutputType'),
+  );
+}
+
+function generateModelCountOutputTypeSelectInputObjectTypes(
+  modelCountOutputTypes: DMMF.OutputType[],
+) {
+  const modelCountOutputTypeSelectInputObjectTypes: DMMF.InputType[] = [];
+  for (const modelCountOutputType of modelCountOutputTypes) {
+    const {
+      name: modelCountOutputTypeName,
+      fields: modelCountOutputTypeFields,
+    } = modelCountOutputType;
+    const modelCountOutputTypeSelectInputObjectType: DMMF.InputType = {
+      name: `${modelCountOutputTypeName}Select`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields: modelCountOutputTypeFields.map(({ name }) => ({
+        name,
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `Boolean`,
+            location: 'scalar',
+          },
+        ],
+      })),
+    };
+    modelCountOutputTypeSelectInputObjectTypes.push(
+      modelCountOutputTypeSelectInputObjectType,
+    );
+  }
+  return modelCountOutputTypeSelectInputObjectTypes;
+}
+
+function generateModelCountOutputTypeArgsInputObjectTypes(
+  modelCountOutputTypes: DMMF.OutputType[],
+) {
+  const modelCountOutputTypeArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const modelCountOutputType of modelCountOutputTypes) {
+    const { name: modelCountOutputTypeName } = modelCountOutputType;
+    const modelCountOutputTypeArgsInputObjectType: DMMF.InputType = {
+      name: `${modelCountOutputTypeName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields: [
+        {
+          name: 'select',
+          isRequired: false,
+          isNullable: false,
+          inputTypes: [
+            {
+              isList: false,
+              type: `${modelCountOutputTypeName}Select`,
+              location: 'inputObjectTypes',
+              namespace: 'prisma',
+            },
+          ],
+        },
+      ],
+    };
+    modelCountOutputTypeArgsInputObjectTypes.push(
+      modelCountOutputTypeArgsInputObjectType,
+    );
+  }
+  return modelCountOutputTypeArgsInputObjectTypes;
+}
+
+function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
+  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    const selectField: DMMF.SchemaArg = {
+      name: 'select',
+      isRequired: false,
+      isNullable: false,
+      inputTypes: [
+        {
+          isList: false,
+          type: `${modelName}Select`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        },
+      ],
+    };
+    fields.push(selectField);
+
+    /** @todo add include field in a future pull request */
+
+    const modelArgsInputObjectType: DMMF.InputType = {
+      name: `${modelName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
+  }
+  return modelArgsInputObjectTypes;
+}
+
+function generateModelSelectInputObjectTypes(models: DMMF.Model[]) {
+  const modelSelectInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName, fields: modelFields } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    let hasManyRelation = false;
+
+    for (const modelField of modelFields) {
+      const {
+        name: modelFieldName,
+        kind,
+        relationName,
+        isList,
+        type,
+      } = modelField;
+
+      const isRelationField = kind === 'object' && !!relationName;
+      if (isRelationField && isList) {
+        hasManyRelation = true;
+      }
+
+      const field: DMMF.SchemaArg = {
+        name: modelFieldName,
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [{ isList: false, type: 'Boolean', location: 'scalar' }],
+      };
+
+      if (isRelationField) {
+        let schemaArgInputType: DMMF.SchemaArgInputType = {
+          isList: false,
+          type: isList ? `${type}FindManyArgs` : `${type}Args`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        };
+        field.inputTypes.push(schemaArgInputType);
+      }
+
+      fields.push(field);
+    }
+
+    const shouldAddCountField = hasManyRelation;
+    if (shouldAddCountField) {
+      const _countField: DMMF.SchemaArg = {
+        name: '_count',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          { isList: false, type: 'Boolean', location: 'scalar' },
+          {
+            isList: false,
+            type: `${modelName}CountOutputTypeArgs`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(_countField);
+    }
+
+    const modelSelectInputObjectType: DMMF.InputType = {
+      name: `${modelName}Select`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelSelectInputObjectTypes.push(modelSelectInputObjectType);
+  }
+  return modelSelectInputObjectTypes;
+}

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -1,123 +1,114 @@
-import { EnvValue, GeneratorOptions } from '@prisma/generator-helper';
+import {
+  DMMF,
+  EnvValue,
+  GeneratorConfig,
+  GeneratorOptions,
+} from '@prisma/generator-helper';
 import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
 import Transformer from './transformer';
 import removeDir from './utils/removeDir';
+import {
+  // addMissingInputObjectTypes,
+  handleMongoDbRawOperationsAndQueries,
+} from './helpers';
 
 export async function generate(options: GeneratorOptions) {
-  const outputDir = parseEnvValue(options.generator.output as EnvValue);
-  await fs.mkdir(outputDir, { recursive: true });
-  await removeDir(outputDir, true);
+  await handleGeneratorOutputValue(options.generator.output as EnvValue);
 
-  const prismaClientProvider = options.otherGenerators.find(
-    (it) => parseEnvValue(it.provider) === 'prisma-client-js',
+  const prismaClientGeneratorConfig = getGeneratorConfigByProvider(
+    options.otherGenerators,
+    'prisma-client-js',
   );
 
   const prismaClientDmmf = await getDMMF({
     datamodel: options.datamodel,
-    previewFeatures: prismaClientProvider?.previewFeatures,
+    previewFeatures: prismaClientGeneratorConfig?.previewFeatures,
   });
+
+  checkForCustomPrismaClientOutputPath(prismaClientGeneratorConfig);
+
+  await generateEnumSchemas(
+    prismaClientDmmf.schema.enumTypes.prisma,
+    prismaClientDmmf.schema.enumTypes.model ?? [],
+  );
+
+  const models = prismaClientDmmf.datamodel.models;
+  const modelOperations = prismaClientDmmf.mappings.modelOperations;
+  const inputObjectTypes = prismaClientDmmf.schema.inputObjectTypes.prisma;
+  const outputObjectTypes = prismaClientDmmf.schema.outputObjectTypes.prisma;
 
   const dataSource = options.datasources?.[0];
-
-  Transformer.isDefaultPrismaClientOutput =
-    prismaClientProvider?.isCustomOutput ?? false;
-
-  if (prismaClientProvider?.isCustomOutput) {
-    Transformer.prismaClientOutputPath =
-      prismaClientProvider?.output?.value ?? '';
-  }
-
-  Transformer.setOutputPath(outputDir);
-
-  const enumTypes = [
-    ...prismaClientDmmf.schema.enumTypes.prisma,
-    ...(prismaClientDmmf.schema.enumTypes.model ?? []),
-  ];
-  const enumNames = enumTypes.map((enumItem) => enumItem.name);
-  Transformer.enumNames = enumNames ?? [];
-  const enumsObj = new Transformer({
-    enumTypes,
-  });
-  await enumsObj.printEnumSchemas();
-
-  const inputObjectTypes = prismaClientDmmf.schema.inputObjectTypes.prisma;
-  const rawOpsMap: { [name: string]: string } = {};
-
-  /* 
-  TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
-  */
-  if (dataSource.provider === 'mongodb') {
-    const modelNames = prismaClientDmmf.mappings.modelOperations.map(
-      (item) => item.model,
-    );
-    const rawOpsNames = [
-      ...new Set(
-        prismaClientDmmf.mappings.modelOperations.reduce<string[]>(
-          (result, current) => {
-            const keys = Object.keys(current);
-            keys?.forEach((key) => {
-              if (key.includes('Raw')) {
-                result.push(key);
-              }
-            });
-            return result;
-          },
-          [],
-        ),
-      ),
-    ];
-
-    rawOpsNames.forEach((opName) => {
-      modelNames.forEach((modelName) => {
-        const isFind = opName === 'findRaw';
-        const opWithModel = `${opName.replace('Raw', '')}${modelName}Raw`;
-        rawOpsMap[opWithModel] = isFind
-          ? `${modelName}FindRawArgs`
-          : `${modelName}AggregateRawArgs`;
-      });
-    });
-
-    Transformer.rawOpsMap = rawOpsMap ?? {};
-
-    const queryOutputTypes =
-      prismaClientDmmf.schema.outputObjectTypes.prisma.filter(
-        (item) => item.name === 'Query',
-      );
-
-    const mongodbRawQueries =
-      queryOutputTypes?.[0].fields.filter((field) =>
-        field.name.includes('Raw'),
-      ) ?? [];
-
-    mongodbRawQueries.forEach((item) => {
-      inputObjectTypes.push({
-        name: item.name,
-        constraints: {
-          maxNumFields: null,
-          minNumFields: null,
-        },
-        fields: item.args.map((arg) => ({
-          name: arg.name,
-          isRequired: arg.isRequired,
-          isNullable: arg.isNullable,
-          inputTypes: arg.inputTypes,
-        })),
-      });
-    });
-  }
-
   Transformer.provider = dataSource.provider;
 
+  // TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
+  if (dataSource.provider === 'mongodb') {
+    handleMongoDbRawOperationsAndQueries(
+      modelOperations,
+      outputObjectTypes,
+      inputObjectTypes,
+    );
+  }
+
+  addMissingInputObjectTypes(inputObjectTypes, outputObjectTypes, models);
+  await generateObjectSchemas(inputObjectTypes);
+
+  await generateModelSchemas(modelOperations);
+}
+
+async function handleGeneratorOutputValue(generatorOuputValue: EnvValue) {
+  const outputDirectoryPath = parseEnvValue(generatorOuputValue);
+
+  // create the output directory and delete contents that might exist from a previous run
+  await fs.mkdir(outputDirectoryPath, { recursive: true });
+  const isRemoveContentsOnly = true;
+  await removeDir(outputDirectoryPath, isRemoveContentsOnly);
+
+  Transformer.setOutputPath(outputDirectoryPath);
+}
+
+function getGeneratorConfigByProvider(
+  generators: GeneratorConfig[],
+  provider: string,
+) {
+  return generators.find((it) => parseEnvValue(it.provider) === provider);
+}
+
+function checkForCustomPrismaClientOutputPath(
+  prismaClientGeneratorConfig: GeneratorConfig | undefined,
+) {
+  if (prismaClientGeneratorConfig?.isCustomOutput) {
+    Transformer.setPrismaClientOutputPath(
+      prismaClientGeneratorConfig.output?.value as string,
+    );
+  }
+}
+
+async function generateEnumSchemas(
+  prismaSchemaEnum: DMMF.SchemaEnum[],
+  modelSchemaEnum: DMMF.SchemaEnum[],
+) {
+  const enumTypes = [...prismaSchemaEnum, ...modelSchemaEnum];
+  const enumNames = enumTypes.map((enumItem) => enumItem.name);
+  Transformer.enumNames = enumNames ?? [];
+  const transformer = new Transformer({
+    enumTypes,
+  });
+  await transformer.generateEnumSchemas();
+}
+
+async function generateObjectSchemas(inputObjectTypes: DMMF.InputType[]) {
   for (let i = 0; i < inputObjectTypes.length; i += 1) {
     const fields = inputObjectTypes[i]?.fields;
     const name = inputObjectTypes[i]?.name;
-    const obj = new Transformer({ name, fields });
-    await obj.printObjectSchemas();
+    const transformer = new Transformer({ name, fields });
+    await transformer.generateObjectSchema();
   }
+}
 
-  const obj = new Transformer({
-    modelOperations: prismaClientDmmf.mappings.modelOperations,
+async function generateModelSchemas(modelOperations: DMMF.ModelMapping[]) {
+  const transformer = new Transformer({
+    modelOperations,
   });
-  await obj.printModelSchemas();
+  await transformer.generateModelSchemas();
 }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -9,7 +9,7 @@ import { promises as fs } from 'fs';
 import Transformer from './transformer';
 import removeDir from './utils/removeDir';
 import {
-  // addMissingInputObjectTypes,
+  addMissingInputObjectTypes,
   handleMongoDbRawOperationsAndQueries,
 } from './helpers';
 

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -6,13 +6,9 @@ import {
 } from '@prisma/generator-helper';
 import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
-import { isAggregateOutputType } from './helpers';
 import Transformer from './transformer';
 import removeDir from './utils/removeDir';
-import {
-  addMissingInputObjectTypes,
-  handleMongoDbRawOperationsAndQueries,
-} from './helpers';
+import { addMissingInputObjectTypes } from './helpers';
 
 export async function generate(options: GeneratorOptions) {
   await handleGeneratorOutputValue(options.generator.output as EnvValue);
@@ -42,23 +38,20 @@ export async function generate(options: GeneratorOptions) {
   const dataSource = options.datasources?.[0];
   Transformer.provider = dataSource.provider;
 
-  // TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
-  if (dataSource.provider === 'mongodb') {
-    handleMongoDbRawOperationsAndQueries(
-      modelOperations,
-      outputObjectTypes,
-      inputObjectTypes,
-    );
-  }
-
-  addMissingInputObjectTypes(inputObjectTypes, outputObjectTypes, models);
+  addMissingInputObjectTypes(
+    inputObjectTypes,
+    outputObjectTypes,
+    models,
+    modelOperations,
+    dataSource.provider,
+  );
   await generateObjectSchemas(inputObjectTypes);
 
   await generateModelSchemas(modelOperations);
 }
 
-async function handleGeneratorOutputValue(generatorOuputValue: EnvValue) {
-  const outputDirectoryPath = parseEnvValue(generatorOuputValue);
+async function handleGeneratorOutputValue(generatorOutputValue: EnvValue) {
+  const outputDirectoryPath = parseEnvValue(generatorOutputValue);
 
   // create the output directory and delete contents that might exist from a previous run
   await fs.mkdir(outputDirectoryPath, { recursive: true });
@@ -81,39 +74,6 @@ function checkForCustomPrismaClientOutputPath(
   if (prismaClientGeneratorConfig?.isCustomOutput) {
     Transformer.setPrismaClientOutputPath(
       prismaClientGeneratorConfig.output?.value as string,
-  const inputObjectTypes = prismaClientDmmf.schema.inputObjectTypes.prisma;
-  const outputObjectTypes = prismaClientDmmf.schema.outputObjectTypes.prisma;
-
-  outputObjectTypes.forEach((outputObjectType) => {
-    if (isAggregateOutputType(outputObjectType.name)) {
-      const name = outputObjectType.name.replace(/(?:OutputType|Output)$/, '');
-      inputObjectTypes.push({
-        constraints: { maxNumFields: null, minNumFields: null },
-        name: `${name}Input`,
-        fields: outputObjectType.fields.map((field) => ({
-          name: field.name,
-          isNullable: false,
-          isRequired: false,
-          inputTypes: [
-            {
-              isList: false,
-              type: 'True',
-              location: 'scalar',
-            },
-          ],
-        })),
-      });
-    }
-  });
-
-  const rawOpsMap: { [name: string]: string } = {};
-
-  /*
-  TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
-  */
-  if (dataSource.provider === 'mongodb') {
-    const modelNames = prismaClientDmmf.mappings.modelOperations.map(
-      (item) => item.model,
     );
   }
 }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -8,7 +8,10 @@ import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
 import Transformer from './transformer';
 import removeDir from './utils/removeDir';
-import { addMissingInputObjectTypes } from './helpers';
+import {
+  addMissingInputObjectTypes,
+  resolveAddMissingInputObjectTypeOptions,
+} from './helpers';
 
 export async function generate(options: GeneratorOptions) {
   await handleGeneratorOutputValue(options.generator.output as EnvValue);
@@ -38,12 +41,16 @@ export async function generate(options: GeneratorOptions) {
   const dataSource = options.datasources?.[0];
   Transformer.provider = dataSource.provider;
 
+  const generatorConfigOptions = options.generator.config;
+  const addMissingInputObjectTypeOptions =
+    resolveAddMissingInputObjectTypeOptions(generatorConfigOptions);
   addMissingInputObjectTypes(
     inputObjectTypes,
     outputObjectTypes,
     models,
     modelOperations,
     dataSource.provider,
+    addMissingInputObjectTypeOptions,
   );
   await generateObjectSchemas(inputObjectTypes);
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -665,7 +665,7 @@ export default class Transformer {
   resolveSelectImportAndZodSchemaLine(modelName: string) {
     const selectImport = Transformer.isGenerateSelect
       ? `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`
-      : undefined;
+      : '';
 
     let selectZodSchemaLine = '';
     let selectZodSchemaLineLazy = '';

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -486,7 +486,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindMany`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
+            `z.object({ select: z.lazy(() => ${modelName}SelectObjectSchema.optional()), where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
           )}`,
         );
       }


### PR DESCRIPTION
Hi Omar I'm BitPhoenix, it's a pleasure to meet you. I wanted to start off by thanking you for creating such an awesome package! It's very useful and has helped me a lot. I really appreciate the hard work you continue to put into it.

My apologies that the refactor and fix are in one pull review, and that the commits are larger than normal. I'll make sure to separate them in the future. 

Since this is quite a big pull request, please let me know if you'd like to hop on a voice chat to go through the changes together, in case that would help make things easier. 

### References
- Support select: https://github.com/omar-dulaimi/prisma-trpc-generator/issues/13
- Support [select relation fields](https://www.prisma.io/docs/concepts/components/prisma-client/select-fields#include-relations-and-select-relation-fields)
- Support [select _count](https://www.prisma.io/docs/concepts/components/prisma-client/select-fields#relation-count)

### Description
I started out by trying to fix the missing select issue referenced here: https://github.com/omar-dulaimi/prisma-trpc-generator/issues/13

To help me better understand the codebase, I started refactoring the `prisma-generator.ts` and `transformer.ts` files as I read through the code to get hands on and aid in understanding. Pretty small things like:
- Extracting grouped logic into functions in `prisma-generator.ts`
- Updating some variable / function names for clarity / consistency
- Reorganizing function order in `transformer.ts` to decrease [vertical distance ](https://mosquitolwz.medium.com/clean-code-quotes-5-formatting-b7bdd4a828d6#:~:text=appear%20vertically%20dense.-,Vertical%20Distance,-Concepts%20that%20are)
- Extracting missing mongo type generation into a separate file + functions

After I finished performing the above changes and understood the codebase, I added functions to `src/helpers/helpers.ts` responsible for generating the types needed to support `select`. I plan on working on `include` next and will likely update the file / folder structure in a future pull request to represent that this group of functions is for adding the select related types (similar to how we now have a file dedicated to mongo missing type generation logic). 

The screenshots below show the generated zod schema which will help a lot to explain what the end goal was of the code that was added to `src/helpers/helpers.ts`. The short version is:
- support select
- support [select relation fields](https://www.prisma.io/docs/concepts/components/prisma-client/select-fields#include-relations-and-select-relation-fields)
- support [select _count](https://www.prisma.io/docs/concepts/components/prisma-client/select-fields#relation-count)

Appropriate queries have a `select` property (Unique example is pictured)
![Screen Shot 2022-10-28 at 3 32 10 PM](https://user-images.githubusercontent.com/46142503/198717786-d871a022-525e-4b0e-8760-624ccf3aab2e.png)

ModelSelect schema is generated. If the model has a **many** relation with another model, we include a union with the find many schema for that model. We also include the `_count` property
![image](https://user-images.githubusercontent.com/46142503/198718415-7eb389ec-ea18-46f1-983a-ff4c28eb6c7d.png)

If the model has a **single** relation with another model, we union with args object schema for that model. If the model does not have a many relation with another model, _count will not be present.
![Screen Shot 2022-10-28 at 3 37 48 PM](https://user-images.githubusercontent.com/46142503/198718687-eab966b3-6683-4ec3-b9c1-4ac5694d8b71.png)
