### PR TITLE
Fix error type name for OrderByAggregateInput

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -247,7 +247,14 @@ export default class Transformer {
         exportName = name.replace('Args', '');
       }
     }
-    if (name.endsWith('AggregateInput')) {
+
+    if (
+      name.endsWith('CountAggregateInput') ||
+      name.endsWith('SumAggregateInput') ||
+      name.endsWith('AvgAggregateInput') ||
+      name.endsWith('MinAggregateInput') ||
+      name.endsWith('MaxAggregateInput')
+    ) {
       name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;


### PR DESCRIPTION
I Found the bug about `OrderByAggregateInput`. It will used wrong type name, when I generate.
It shouldn't add `Type` after `OrderByAggregateInput` type.
So, I strictly checked `endsWith`.
Sorry for not checking all generated type.