### PR TITLE
Include support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,8 +10,8 @@ datasource db {
 generator zod {
   provider          = "node ./lib/generator.js"
   output            = "./generated"
-  isGenerateSelect  = false
-  isGenerateInclude = false
+  isGenerateSelect  = true
+  isGenerateInclude = true
 }
 
 model User {
@@ -31,4 +31,5 @@ model Post {
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
+  likes     BigInt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,9 +8,10 @@ datasource db {
 }
 
 generator zod {
-  provider = "node ./lib/generator.js"
-  output   = "./generated"  
-  isGenerateSelect = true
+  provider          = "node ./lib/generator.js"
+  output            = "./generated"
+  isGenerateSelect  = false
+  isGenerateInclude = false
 }
 
 model User {
@@ -30,5 +31,4 @@ model Post {
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
-  likes     BigInt
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -3,9 +3,12 @@ import Transformer from '../transformer';
 import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
 import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
 import { addMissingInputObjectTypesForSelect } from './select-helpers';
+import { addMissingInputObjectTypesForInclude } from './include-helpers';
+import { addMissingInputObjectTypesForModelArgs } from './modelArgs-helpers';
 
 interface AddMissingInputObjectTypeOptions {
   isGenerateSelect: boolean;
+  isGenerateInclude: boolean;
 }
 
 export function addMissingInputObjectTypes(
@@ -33,6 +36,22 @@ export function addMissingInputObjectTypes(
     );
     Transformer.setIsGenerateSelect(true);
   }
+  if (options.isGenerateSelect || options.isGenerateInclude) {
+    addMissingInputObjectTypesForModelArgs(
+      inputObjectTypes,
+      models,
+      options.isGenerateSelect,
+      options.isGenerateInclude,
+    );
+  }
+  if (options.isGenerateInclude) {
+    addMissingInputObjectTypesForInclude(
+      inputObjectTypes,
+      models,
+      options.isGenerateSelect,
+    );
+    Transformer.setIsGenerateInclude(true);
+  }
 }
 
 export function resolveAddMissingInputObjectTypeOptions(
@@ -40,78 +59,6 @@ export function resolveAddMissingInputObjectTypeOptions(
 ): AddMissingInputObjectTypeOptions {
   return {
     isGenerateSelect: generatorConfigOptions.isGenerateSelect === 'true',
+    isGenerateInclude: generatorConfigOptions.isGenerateInclude === 'true',
   };
-}
-
-function generateModelIncludeInputObjectTypes(models: DMMF.Model[]) {
-  const modelIncludeInputObjectTypes: DMMF.InputType[] = [];
-  for (const model of models) {
-    const { name: modelName, fields: modelFields } = model;
-    const fields: DMMF.SchemaArg[] = [];
-
-    let hasManyRelation = false;
-
-    for (const modelField of modelFields) {
-      const {
-        name: modelFieldName,
-        kind,
-        relationName,
-        isList,
-        type,
-      } = modelField;
-
-      const isRelationField = kind === 'object' && !!relationName;
-      if (isRelationField && isList) {
-        hasManyRelation = true;
-      }
-
-      if (isRelationField) {
-        const field: DMMF.SchemaArg = {
-          name: modelFieldName,
-          isRequired: false,
-          isNullable: false,
-          inputTypes: [
-            { isList: false, type: 'Boolean', location: 'scalar' },
-            {
-              isList: false,
-              type: isList ? `${type}FindManyArgs` : `${type}Args`,
-              location: 'inputObjectTypes',
-              namespace: 'prisma',
-            },
-          ],
-        };
-        fields.push(field);
-      }
-    }
-
-    const shouldAddCountField = hasManyRelation;
-    if (shouldAddCountField) {
-      const _countField: DMMF.SchemaArg = {
-        name: '_count',
-        isRequired: false,
-        isNullable: false,
-        inputTypes: [
-          { isList: false, type: 'Boolean', location: 'scalar' },
-          {
-            isList: false,
-            type: `${modelName}CountOutputTypeArgs`,
-            location: 'inputObjectTypes',
-            namespace: 'prisma',
-          },
-        ],
-      };
-      fields.push(_countField);
-    }
-
-    const modelIncludeInputObjectType: DMMF.InputType = {
-      name: `${modelName}Include`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields,
-    };
-    modelIncludeInputObjectTypes.push(modelIncludeInputObjectType);
-  }
-  return modelIncludeInputObjectTypes;
 }

--- a/src/helpers/include-helpers.ts
+++ b/src/helpers/include-helpers.ts
@@ -1,0 +1,99 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypesForInclude(
+  inputObjectTypes: DMMF.InputType[],
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+) {
+  // generate input object types necessary to support ModelInclude with relation support
+  const modelIncludeInputObjectTypes = generateModelIncludeInputObjectTypes(
+    models,
+    isGenerateSelect,
+  );
+
+  const generatedIncludeInputObjectTypes = [
+    modelIncludeInputObjectTypes,
+  ].flat();
+
+  for (const includeInputObjectType of generatedIncludeInputObjectTypes) {
+    inputObjectTypes.push(includeInputObjectType);
+  }
+}
+function generateModelIncludeInputObjectTypes(
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+) {
+  const modelIncludeInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName, fields: modelFields } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    let hasManyRelation = false;
+
+    for (const modelField of modelFields) {
+      const {
+        name: modelFieldName,
+        kind,
+        relationName,
+        isList,
+        type,
+      } = modelField;
+
+      const isRelationField = kind === 'object' && !!relationName;
+      if (isRelationField && isList) {
+        hasManyRelation = true;
+      }
+
+      if (isRelationField) {
+        const field: DMMF.SchemaArg = {
+          name: modelFieldName,
+          isRequired: false,
+          isNullable: false,
+          inputTypes: [
+            { isList: false, type: 'Boolean', location: 'scalar' },
+            {
+              isList: false,
+              type: isList ? `${type}FindManyArgs` : `${type}Args`,
+              location: 'inputObjectTypes',
+              namespace: 'prisma',
+            },
+          ],
+        };
+        fields.push(field);
+      }
+    }
+
+    const shouldAddCountField = hasManyRelation;
+    if (shouldAddCountField) {
+      const inputTypes: DMMF.SchemaArgInputType[] = [
+        { isList: false, type: 'Boolean', location: 'scalar' },
+      ];
+      if (isGenerateSelect) {
+        inputTypes.push({
+          isList: false,
+          type: `${modelName}CountOutputTypeArgs`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        });
+      }
+      const _countField: DMMF.SchemaArg = {
+        name: '_count',
+        isRequired: false,
+        isNullable: false,
+        inputTypes,
+      };
+      fields.push(_countField);
+    }
+
+    const modelIncludeInputObjectType: DMMF.InputType = {
+      name: `${modelName}Include`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelIncludeInputObjectTypes.push(modelIncludeInputObjectType);
+  }
+  return modelIncludeInputObjectTypes;
+}

--- a/src/helpers/modelArgs-helpers.ts
+++ b/src/helpers/modelArgs-helpers.ts
@@ -12,9 +12,7 @@ export function addMissingInputObjectTypesForModelArgs(
     isGenerateInclude,
   );
 
-  const generatedModelArgsInputObjectTypes = [modelArgsInputObjectTypes].flat();
-
-  for (const modelArgsInputObjectType of generatedModelArgsInputObjectTypes) {
+  for (const modelArgsInputObjectType of modelArgsInputObjectTypes) {
     inputObjectTypes.push(modelArgsInputObjectType);
   }
 }

--- a/src/helpers/modelArgs-helpers.ts
+++ b/src/helpers/modelArgs-helpers.ts
@@ -1,0 +1,76 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypesForModelArgs(
+  inputObjectTypes: DMMF.InputType[],
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+  isGenerateInclude: boolean,
+) {
+  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(
+    models,
+    isGenerateSelect,
+    isGenerateInclude,
+  );
+
+  const generatedModelArgsInputObjectTypes = [modelArgsInputObjectTypes].flat();
+
+  for (const modelArgsInputObjectType of generatedModelArgsInputObjectTypes) {
+    inputObjectTypes.push(modelArgsInputObjectType);
+  }
+}
+function generateModelArgsInputObjectTypes(
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+  isGenerateInclude: boolean,
+) {
+  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    if (isGenerateSelect) {
+      const selectField: DMMF.SchemaArg = {
+        name: 'select',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `${modelName}Select`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(selectField);
+    }
+
+    if (isGenerateInclude) {
+      const includeField: DMMF.SchemaArg = {
+        name: 'include',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `${modelName}Include`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(includeField);
+    }
+
+    const modelArgsInputObjectType: DMMF.InputType = {
+      name: `${modelName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
+  }
+  return modelArgsInputObjectTypes;
+}

--- a/src/helpers/select-helpers.ts
+++ b/src/helpers/select-helpers.ts
@@ -12,15 +12,12 @@ export function addMissingInputObjectTypesForSelect(
   const modelCountOutputTypeArgsInputObjectTypes =
     generateModelCountOutputTypeArgsInputObjectTypes(modelCountOutputTypes);
 
-  // generate input object types necessary to support ModelSelect with relation support
-  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(models);
   const modelSelectInputObjectTypes =
     generateModelSelectInputObjectTypes(models);
 
   const generatedInputObjectTypes = [
     modelCountOutputTypeSelectInputObjectTypes,
     modelCountOutputTypeArgsInputObjectTypes,
-    modelArgsInputObjectTypes,
     modelSelectInputObjectTypes,
   ].flat();
 
@@ -126,7 +123,20 @@ function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
     };
     fields.push(selectField);
 
-    /** @todo add include field in a future pull request */
+    const includeField: DMMF.SchemaArg = {
+      name: 'include',
+      isRequired: false,
+      isNullable: false,
+      inputTypes: [
+        {
+          isList: false,
+          type: `${modelName}Include`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        },
+      ],
+    };
+    fields.push(includeField);
 
     const modelArgsInputObjectType: DMMF.InputType = {
       name: `${modelName}Args`,

--- a/src/helpers/select-helpers.ts
+++ b/src/helpers/select-helpers.ts
@@ -102,55 +102,6 @@ function generateModelCountOutputTypeArgsInputObjectTypes(
   return modelCountOutputTypeArgsInputObjectTypes;
 }
 
-function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
-  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
-  for (const model of models) {
-    const { name: modelName } = model;
-    const fields: DMMF.SchemaArg[] = [];
-
-    const selectField: DMMF.SchemaArg = {
-      name: 'select',
-      isRequired: false,
-      isNullable: false,
-      inputTypes: [
-        {
-          isList: false,
-          type: `${modelName}Select`,
-          location: 'inputObjectTypes',
-          namespace: 'prisma',
-        },
-      ],
-    };
-    fields.push(selectField);
-
-    const includeField: DMMF.SchemaArg = {
-      name: 'include',
-      isRequired: false,
-      isNullable: false,
-      inputTypes: [
-        {
-          isList: false,
-          type: `${modelName}Include`,
-          location: 'inputObjectTypes',
-          namespace: 'prisma',
-        },
-      ],
-    };
-    fields.push(includeField);
-
-    const modelArgsInputObjectType: DMMF.InputType = {
-      name: `${modelName}Args`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields,
-    };
-    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
-  }
-  return modelArgsInputObjectTypes;
-}
-
 function generateModelSelectInputObjectTypes(models: DMMF.Model[]) {
   const modelSelectInputObjectTypes: DMMF.InputType[] = [];
   for (const model of models) {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -700,12 +700,12 @@ export default class Transformer {
     let selectZodSchemaLineLazy = '';
     let includeZodSchemaLineLazy = '';
     if (Transformer.isGenerateSelect) {
-      let zodSelectObjectSchema = `${modelName}SelectObjectSchema.optional()`;
+      const zodSelectObjectSchema = `${modelName}SelectObjectSchema.optional()`;
       selectZodSchemaLine = `select: ${zodSelectObjectSchema},`;
       selectZodSchemaLineLazy = `select: z.lazy(() => ${zodSelectObjectSchema}),`;
     }
     if (Transformer.isGenerateInclude) {
-      let zodIncludeObjectSchema = `${modelName}IncludeObjectSchema.optional()`;
+      const zodIncludeObjectSchema = `${modelName}IncludeObjectSchema.optional()`;
       includeZodSchemaLine = `include: ${zodIncludeObjectSchema},`;
       includeZodSchemaLineLazy = `include: z.lazy(() => ${zodIncludeObjectSchema}),`;
     }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -433,6 +433,7 @@ export default class Transformer {
       if (findUnique) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -441,7 +442,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindUnique`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), where: ${modelName}WhereUniqueInputObjectSchema })`,
+            `z.object({ select: ${modelName}SelectObjectSchema.optional(), include: ${modelName}IncludeObjectSchema.optional(), where: ${modelName}WhereUniqueInputObjectSchema })`,
           )}`,
         );
       }
@@ -449,6 +450,7 @@ export default class Transformer {
       if (findFirst) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -460,7 +462,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindFirst`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
+            `z.object({ select: ${modelName}SelectObjectSchema.optional(), include: ${modelName}IncludeObjectSchema.optional(), where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
           )}`,
         );
       }
@@ -468,6 +470,7 @@ export default class Transformer {
       if (findMany) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -479,7 +482,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindMany`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
+            `z.object({ select: z.lazy(() => ${modelName}SelectObjectSchema.optional()), include: z.lazy(() => ${modelName}IncludeObjectSchema.optional()), where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
           )}`,
         );
       }
@@ -487,6 +490,7 @@ export default class Transformer {
       if (createOne) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
         ];
         await writeFileSafely(
@@ -495,7 +499,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateOne`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), data: ${modelName}CreateInputObjectSchema  })`,
+            `z.object({ select: ${modelName}SelectObjectSchema.optional(), include: ${modelName}IncludeObjectSchema.optional(), data: ${modelName}CreateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -518,6 +522,7 @@ export default class Transformer {
       if (deleteOne) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -526,7 +531,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}DeleteOne`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ select: ${modelName}SelectObjectSchema.optional(), include: ${modelName}IncludeObjectSchema.optional(), where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -549,6 +554,7 @@ export default class Transformer {
       if (updateOne) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
@@ -558,7 +564,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}UpdateOne`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ select: ${modelName}SelectObjectSchema.optional(), include: ${modelName}IncludeObjectSchema.optional(), data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -582,6 +588,7 @@ export default class Transformer {
       if (upsertOne) {
         const imports = [
           `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`,
+          `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
@@ -592,7 +599,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}Upsert`,
-            `z.object({ select: ${modelName}SelectObjectSchema.optional(), where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
+            `z.object({ select: ${modelName}SelectObjectSchema.optional(), include: ${modelName}IncludeObjectSchema.optional(), where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -19,6 +19,7 @@ export default class Transformer {
   private static prismaClientOutputPath: string = '@prisma/client';
   private static isCustomPrismaClientOutputPath: boolean = false;
   private static isGenerateSelect: boolean = false;
+  private static isGenerateInclude: boolean = false;
 
   constructor(params: TransformerParams) {
     this.name = params.name ?? '';
@@ -33,6 +34,10 @@ export default class Transformer {
 
   static setIsGenerateSelect(isGenerateSelect: boolean) {
     this.isGenerateSelect = isGenerateSelect;
+  }
+
+  static setIsGenerateInclude(isGenerateInclude: boolean) {
+    this.isGenerateInclude = isGenerateInclude;
   }
 
   static getOutputPath() {
@@ -449,12 +454,19 @@ export default class Transformer {
         groupBy,
       } = model;
 
-      const { selectImport, selectZodSchemaLine, selectZodSchemaLineLazy } =
-        this.resolveSelectImportAndZodSchemaLine(modelName);
+      const {
+        selectImport,
+        includeImport,
+        selectZodSchemaLine,
+        includeZodSchemaLine,
+        selectZodSchemaLineLazy,
+        includeZodSchemaLineLazy,
+      } = this.resolveSelectIncludeImportAndZodSchemaLine(modelName);
 
       if (findUnique) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -463,7 +475,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindUnique`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema })`,
           )}`,
         );
       }
@@ -471,6 +483,7 @@ export default class Transformer {
       if (findFirst) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -482,7 +495,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindFirst`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
           )}`,
         );
       }
@@ -490,6 +503,7 @@ export default class Transformer {
       if (findMany) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -501,7 +515,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindMany`,
-            `z.object({ ${selectZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
+            `z.object({ ${selectZodSchemaLineLazy} ${includeZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
           )}`,
         );
       }
@@ -509,6 +523,7 @@ export default class Transformer {
       if (createOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
         ];
         await writeFileSafely(
@@ -517,7 +532,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateOne`,
-            `z.object({ ${selectZodSchemaLine} data: ${modelName}CreateInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: ${modelName}CreateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -540,6 +555,7 @@ export default class Transformer {
       if (deleteOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -548,7 +564,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}DeleteOne`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -571,6 +587,7 @@ export default class Transformer {
       if (updateOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
@@ -580,7 +597,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}UpdateOne`,
-            `z.object({ ${selectZodSchemaLine} data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -604,6 +621,7 @@ export default class Transformer {
       if (upsertOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
@@ -614,7 +632,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}Upsert`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -669,18 +687,35 @@ export default class Transformer {
     return generatedImports;
   }
 
-  resolveSelectImportAndZodSchemaLine(modelName: string) {
+  resolveSelectIncludeImportAndZodSchemaLine(modelName: string) {
     const selectImport = Transformer.isGenerateSelect
       ? `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`
       : '';
+    const includeImport = Transformer.isGenerateInclude
+      ? `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`
+      : '';
 
     let selectZodSchemaLine = '';
+    let includeZodSchemaLine = '';
     let selectZodSchemaLineLazy = '';
+    let includeZodSchemaLineLazy = '';
     if (Transformer.isGenerateSelect) {
       let zodSelectObjectSchema = `${modelName}SelectObjectSchema.optional()`;
       selectZodSchemaLine = `select: ${zodSelectObjectSchema},`;
       selectZodSchemaLineLazy = `select: z.lazy(() => ${zodSelectObjectSchema}),`;
     }
-    return { selectImport, selectZodSchemaLine, selectZodSchemaLineLazy };
+    if (Transformer.isGenerateInclude) {
+      let zodIncludeObjectSchema = `${modelName}IncludeObjectSchema.optional()`;
+      includeZodSchemaLine = `include: ${zodIncludeObjectSchema},`;
+      includeZodSchemaLineLazy = `include: z.lazy(() => ${zodIncludeObjectSchema}),`;
+    }
+    return {
+      selectImport,
+      includeImport,
+      selectZodSchemaLine,
+      includeZodSchemaLine,
+      selectZodSchemaLineLazy,
+      includeZodSchemaLineLazy,
+    };
   }
 }


### PR DESCRIPTION
Hi @omar-dulaimi
Thanks for creating this useful package. This is my first contribution to an open-source project. Hope my PR  will be good enough to contribute to this project.

Here are the things I have added or changed to make things work.

- I added `isGenerateInclude` flag to control `include field` on schema. The default value of the flags is false.
![Screenshot from 2022-11-05 02-41-13](https://user-images.githubusercontent.com/62707100/200071791-347d21d2-0df4-481a-b4f3-6fa333bdd192.png)

- Since we have now two flags `(select and include)`, I am required to move the `generateModelArgsInputObjectTypes` function from `select-helpers` to a newly created file `modelArgs-helpers`. Because `schemas/objects/{model}Args` files should be generated if any of the two flags is active.

- Previously we were generating `_count` field whenever we found a model with `manyRelation`. But since the `isGenerateSelect` could be false, we will now add `{model}CountOutputTypeArgs` field in `_count` only if the `isGenerateSelect` flag is true.
![Screenshot from 2022-11-05 02-42-49](https://user-images.githubusercontent.com/62707100/200071874-9185e2b5-840a-4f96-a713-6199edd7e0a7.png)