### PR TITLE
Fix bug aggregate operation when Model has only string

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,8 +8,8 @@ datasource db {
 }
 
 generator zod {
-  provider = "node ./lib/generator.js"
-  output   = "./generated"  
+  provider         = "node ./lib/generator.js"
+  output           = "./generated"
   isGenerateSelect = true
 }
 
@@ -31,4 +31,9 @@ model Post {
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
   likes     BigInt
+}
+
+model Map {
+  key   String @id
+  value String
 }

--- a/src/helpers/aggregate-helpers.ts
+++ b/src/helpers/aggregate-helpers.ts
@@ -1,4 +1,5 @@
 import { DMMF } from '@prisma/generator-helper';
+import { AggregateOperationSupport } from '../types';
 
 const isAggregateOutputType = (name: string) =>
   /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);
@@ -38,22 +39,12 @@ export function addMissingInputObjectTypesForAggregate(
   }
 }
 
-export type AggregateOperationSupport = {
-  [model: string]: {
-    count?: boolean;
-    min?: boolean;
-    max?: boolean;
-    sum?: boolean;
-    avg?: boolean;
-  };
-};
-
 export function resolveAggregateOperationSupport(
   inputObjectTypes: DMMF.InputType[],
 ) {
   const aggregateOperationSupport: AggregateOperationSupport = {};
   for (const inputType of inputObjectTypes) {
-    if (isAggreateInputType(inputType.name)) {
+    if (isAggregateInputType(inputType.name)) {
       const name = inputType.name.replace('AggregateInput', '');
       if (name.endsWith('Count')) {
         const model = name.replace('Count', '');

--- a/src/helpers/aggregate-helpers.ts
+++ b/src/helpers/aggregate-helpers.ts
@@ -3,7 +3,7 @@ import { DMMF } from '@prisma/generator-helper';
 const isAggregateOutputType = (name: string) =>
   /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);
 
-export const isAggreateInputType = (name: string) =>
+export const isAggregateInputType = (name: string) =>
   name.endsWith('CountAggregateInput') ||
   name.endsWith('SumAggregateInput') ||
   name.endsWith('AvgAggregateInput') ||

--- a/src/helpers/aggregate-helpers.ts
+++ b/src/helpers/aggregate-helpers.ts
@@ -3,6 +3,13 @@ import { DMMF } from '@prisma/generator-helper';
 const isAggregateOutputType = (name: string) =>
   /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);
 
+export const isAggreateInputType = (name: string) =>
+  name.endsWith('CountAggregateInput') ||
+  name.endsWith('SumAggregateInput') ||
+  name.endsWith('AvgAggregateInput') ||
+  name.endsWith('MinAggregateInput') ||
+  name.endsWith('MaxAggregateInput');
+
 export function addMissingInputObjectTypesForAggregate(
   inputObjectTypes: DMMF.InputType[],
   outputObjectTypes: DMMF.OutputType[],
@@ -29,4 +36,57 @@ export function addMissingInputObjectTypesForAggregate(
       })),
     });
   }
+}
+
+export type AggregateOperationSupport = {
+  [model: string]: {
+    count?: boolean;
+    min?: boolean;
+    max?: boolean;
+    sum?: boolean;
+    avg?: boolean;
+  };
+};
+
+export function resolveAggregateOperationSupport(
+  inputObjectTypes: DMMF.InputType[],
+) {
+  const aggregateOperationSupport: AggregateOperationSupport = {};
+  for (const inputType of inputObjectTypes) {
+    if (isAggreateInputType(inputType.name)) {
+      const name = inputType.name.replace('AggregateInput', '');
+      if (name.endsWith('Count')) {
+        const model = name.replace('Count', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          count: true,
+        };
+      } else if (name.endsWith('Min')) {
+        const model = name.replace('Min', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          min: true,
+        };
+      } else if (name.endsWith('Max')) {
+        const model = name.replace('Max', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          max: true,
+        };
+      } else if (name.endsWith('Sum')) {
+        const model = name.replace('Sum', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          sum: true,
+        };
+      } else if (name.endsWith('Avg')) {
+        const model = name.replace('Avg', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          avg: true,
+        };
+      }
+    }
+  }
+  return aggregateOperationSupport;
 }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -11,10 +11,10 @@ import {
   resolveAddMissingInputObjectTypeOptions,
 } from './helpers';
 import {
-  AggregateOperationSupport,
   resolveAggregateOperationSupport,
 } from './helpers/aggregate-helpers';
 import Transformer from './transformer';
+import { AggregateOperationSupport } from './types';
 import removeDir from './utils/removeDir';
 
 export async function generate(options: GeneratorOptions) {

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -6,12 +6,16 @@ import {
 } from '@prisma/generator-helper';
 import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
-import Transformer from './transformer';
-import removeDir from './utils/removeDir';
 import {
   addMissingInputObjectTypes,
   resolveAddMissingInputObjectTypeOptions,
 } from './helpers';
+import {
+  AggregateOperationSupport,
+  resolveAggregateOperationSupport,
+} from './helpers/aggregate-helpers';
+import Transformer from './transformer';
+import removeDir from './utils/removeDir';
 
 export async function generate(options: GeneratorOptions) {
   await handleGeneratorOutputValue(options.generator.output as EnvValue);
@@ -54,7 +58,10 @@ export async function generate(options: GeneratorOptions) {
   );
   await generateObjectSchemas(inputObjectTypes);
 
-  await generateModelSchemas(modelOperations);
+  const aggregateOperationSupport =
+    resolveAggregateOperationSupport(inputObjectTypes);
+
+  await generateModelSchemas(modelOperations, aggregateOperationSupport);
 }
 
 async function handleGeneratorOutputValue(generatorOutputValue: EnvValue) {
@@ -107,9 +114,13 @@ async function generateObjectSchemas(inputObjectTypes: DMMF.InputType[]) {
   }
 }
 
-async function generateModelSchemas(modelOperations: DMMF.ModelMapping[]) {
+async function generateModelSchemas(
+  modelOperations: DMMF.ModelMapping[],
+  aggregateOperationSupport: AggregateOperationSupport,
+) {
   const transformer = new Transformer({
     modelOperations,
+    aggregateOperationSupport,
   });
   await transformer.generateModelSchemas();
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -2,10 +2,9 @@ import type { DMMF as PrismaDMMF } from '@prisma/generator-helper';
 import path from 'path';
 import { isMongodbRawOp } from './helpers';
 import {
-  AggregateOperationSupport,
-  isAggreateInputType,
+  isAggregateInputType,
 } from './helpers/aggregate-helpers';
-import { TransformerParams } from './types';
+import { AggregateOperationSupport, TransformerParams } from './types';
 import { writeFileSafely } from './utils/writeFileSafely';
 
 export default class Transformer {
@@ -283,7 +282,7 @@ export default class Transformer {
       }
     }
 
-    if (isAggreateInputType(name)) {
+    if (isAggregateInputType(name)) {
       name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,6 +1,10 @@
 import type { DMMF as PrismaDMMF } from '@prisma/generator-helper';
 import path from 'path';
 import { isMongodbRawOp } from './helpers';
+import {
+  AggregateOperationSupport,
+  isAggreateInputType,
+} from './helpers/aggregate-helpers';
 import { TransformerParams } from './types';
 import { writeFileSafely } from './utils/writeFileSafely';
 
@@ -9,6 +13,7 @@ export default class Transformer {
   fields: PrismaDMMF.SchemaArg[];
   schemaImports = new Set<string>();
   modelOperations: PrismaDMMF.ModelMapping[];
+  aggregateOperationSupport: AggregateOperationSupport;
   enumTypes: PrismaDMMF.SchemaEnum[];
 
   static enumNames: string[] = [];
@@ -24,6 +29,7 @@ export default class Transformer {
     this.name = params.name ?? '';
     this.fields = params.fields ?? [];
     this.modelOperations = params.modelOperations ?? [];
+    this.aggregateOperationSupport = params.aggregateOperationSupport ?? {};
     this.enumTypes = params.enumTypes ?? [];
   }
 
@@ -272,13 +278,7 @@ export default class Transformer {
       }
     }
 
-    if (
-      name.endsWith('CountAggregateInput') ||
-      name.endsWith('SumAggregateInput') ||
-      name.endsWith('AvgAggregateInput') ||
-      name.endsWith('MinAggregateInput') ||
-      name.endsWith('MaxAggregateInput')
-    ) {
+    if (isAggreateInputType(name)) {
       name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;
@@ -624,19 +624,58 @@ export default class Transformer {
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
-          `import { ${modelName}CountAggregateInputObjectSchema } from './objects/${modelName}CountAggregateInput.schema'`,
-          `import { ${modelName}MinAggregateInputObjectSchema } from './objects/${modelName}MinAggregateInput.schema'`,
-          `import { ${modelName}MaxAggregateInputObjectSchema } from './objects/${modelName}MaxAggregateInput.schema'`,
-          `import { ${modelName}AvgAggregateInputObjectSchema } from './objects/${modelName}AvgAggregateInput.schema'`,
-          `import { ${modelName}SumAggregateInputObjectSchema } from './objects/${modelName}SumAggregateInput.schema'`,
         ];
+        const aggregateOperations = [];
+        if (this.aggregateOperationSupport[modelName].count) {
+          imports.push(
+            `import { ${modelName}CountAggregateInputObjectSchema } from './objects/${modelName}CountAggregateInput.schema'`,
+          );
+          aggregateOperations.push(
+            `_count: z.union([ z.literal(true), ${modelName}CountAggregateInputObjectSchema ]).optional()`,
+          );
+        }
+        if (this.aggregateOperationSupport[modelName].min) {
+          imports.push(
+            `import { ${modelName}MinAggregateInputObjectSchema } from './objects/${modelName}MinAggregateInput.schema'`,
+          );
+          aggregateOperations.push(
+            `_min: ${modelName}MinAggregateInputObjectSchema.optional()`,
+          );
+        }
+        if (this.aggregateOperationSupport[modelName].max) {
+          imports.push(
+            `import { ${modelName}MaxAggregateInputObjectSchema } from './objects/${modelName}MaxAggregateInput.schema'`,
+          );
+          aggregateOperations.push(
+            `_max: ${modelName}MaxAggregateInputObjectSchema.optional()`,
+          );
+        }
+        if (this.aggregateOperationSupport[modelName].avg) {
+          imports.push(
+            `import { ${modelName}AvgAggregateInputObjectSchema } from './objects/${modelName}AvgAggregateInput.schema'`,
+          );
+          aggregateOperations.push(
+            `_avg: ${modelName}AvgAggregateInputObjectSchema.optional()`,
+          );
+        }
+        if (this.aggregateOperationSupport[modelName].sum) {
+          imports.push(
+            `import { ${modelName}SumAggregateInputObjectSchema } from './objects/${modelName}SumAggregateInput.schema'`,
+          );
+          aggregateOperations.push(
+            `_sum: ${modelName}SumAggregateInputObjectSchema.optional()`,
+          );
+        }
+
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${aggregate}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}Aggregate`,
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), _count: z.union([ z.literal(true), ${modelName}CountAggregateInputObjectSchema ]).optional(), _min: ${modelName}MinAggregateInputObjectSchema.optional(), _max: ${modelName}MaxAggregateInputObjectSchema.optional(), _avg: ${modelName}AvgAggregateInputObjectSchema.optional(), _sum: ${modelName}SumAggregateInputObjectSchema.optional()  })`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), ${aggregateOperations.join(
+              ', ',
+            )} })`,
           )}`,
         );
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
 import { DMMF as PrismaDMMF } from '@prisma/client/runtime';
+import { AggregateOperationSupport } from './helpers/aggregate-helpers';
 
 export type TransformerParams = {
   enumTypes?: PrismaDMMF.SchemaEnum[];
   fields?: PrismaDMMF.SchemaArg[];
   name?: string;
   modelOperations?: PrismaDMMF.ModelMapping[];
+  aggregateOperationSupport?: AggregateOperationSupport;
   isDefaultPrismaClientOutput?: boolean;
   prismaClientOutputPath?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { DMMF as PrismaDMMF } from '@prisma/client/runtime';
-import { AggregateOperationSupport } from './helpers/aggregate-helpers';
 
 export type TransformerParams = {
   enumTypes?: PrismaDMMF.SchemaEnum[];
@@ -9,4 +8,14 @@ export type TransformerParams = {
   aggregateOperationSupport?: AggregateOperationSupport;
   isDefaultPrismaClientOutput?: boolean;
   prismaClientOutputPath?: string;
+};
+
+export type AggregateOperationSupport = {
+  [model: string]: {
+    count?: boolean;
+    min?: boolean;
+    max?: boolean;
+    sum?: boolean;
+    avg?: boolean;
+  };
 };


### PR DESCRIPTION
Hi @omar-dulaimi ,

I found another bug. Similar with #34 

In case your model doesn't have number type like this.
```
model Map {
  key   String @id
  value String
}
```
`prisma-client-js` will not generate `_sum` and `_avg` in aggregate type.
```
 export type MapAggregateArgs = {
    where?: MapWhereInput
    orderBy?: Enumerable<MapOrderByWithRelationInput>
    cursor?: MapWhereUniqueInput
    take?: number
    skip?: number
    _count?: true | MapCountAggregateInputType
    _min?: MapMinAggregateInputType
    _max?: MapMaxAggregateInputType
  }
  ```
  So, I fixed this by removing `_sum` and `_avg`.