### PR TITLE
Fixed bug: include no longer generated for models that do not have relations with other models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,3 +33,8 @@ model Post {
   authorId  Int?
   likes     BigInt
 }
+
+model Book {
+  id Int @unique
+  title String
+}

--- a/src/helpers/include-helpers.ts
+++ b/src/helpers/include-helpers.ts
@@ -28,6 +28,7 @@ function generateModelIncludeInputObjectTypes(
     const { name: modelName, fields: modelFields } = model;
     const fields: DMMF.SchemaArg[] = [];
 
+    let hasRelation = false;
     let hasManyRelation = false;
 
     for (const modelField of modelFields) {
@@ -40,8 +41,11 @@ function generateModelIncludeInputObjectTypes(
       } = modelField;
 
       const isRelationField = kind === 'object' && !!relationName;
-      if (isRelationField && isList) {
-        hasManyRelation = true;
+      if (isRelationField) {
+        hasRelation = true;
+        if (isList) {
+          hasManyRelation = true;
+        }
       }
 
       if (isRelationField) {
@@ -61,6 +65,14 @@ function generateModelIncludeInputObjectTypes(
         };
         fields.push(field);
       }
+    }
+
+    /**
+     * include is not generated for models that do not have relations with any other models
+     * continue on to the next model
+     */
+    if (!hasRelation) {
+      continue;
     }
 
     const shouldAddCountField = hasManyRelation;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './helpers';
+export * from './model-helpers';
 export * from './mongodb-helpers';

--- a/src/helpers/model-helpers.ts
+++ b/src/helpers/model-helpers.ts
@@ -1,0 +1,36 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function checkModelHasModelRelation(model: DMMF.Model) {
+  const { fields: modelFields } = model;
+  for (const modelField of modelFields) {
+    const isRelationField = checkIsModelRelationField(modelField);
+    if (isRelationField) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function checkModelHasManyModelRelation(model: DMMF.Model) {
+  const { fields: modelFields } = model;
+  for (const modelField of modelFields) {
+    const isManyRelationField = checkIsManyModelRelationField(modelField);
+    if (isManyRelationField) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function checkIsModelRelationField(modelField: DMMF.Field) {
+  const { kind, relationName } = modelField;
+  return kind === 'object' && !!relationName;
+}
+
+export function checkIsManyModelRelationField(modelField: DMMF.Field) {
+  return checkIsModelRelationField(modelField) && modelField.isList;
+}
+
+export function findModelByName(models: DMMF.Model[], modelName: string) {
+  return models.find(({ name }) => name === modelName);
+}

--- a/src/helpers/modelArgs-helpers.ts
+++ b/src/helpers/modelArgs-helpers.ts
@@ -1,4 +1,5 @@
 import { DMMF } from '@prisma/generator-helper';
+import { checkModelHasModelRelation } from './model-helpers';
 
 export function addMissingInputObjectTypesForModelArgs(
   inputObjectTypes: DMMF.InputType[],
@@ -43,7 +44,9 @@ function generateModelArgsInputObjectTypes(
       fields.push(selectField);
     }
 
-    if (isGenerateInclude) {
+    const hasRelationToAnotherModel = checkModelHasModelRelation(model);
+
+    if (isGenerateInclude && hasRelationToAnotherModel) {
       const includeField: DMMF.SchemaArg = {
         name: 'include',
         isRequired: false,

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -54,7 +54,7 @@ export async function generate(options: GeneratorOptions) {
   );
   await generateObjectSchemas(inputObjectTypes);
 
-  await generateModelSchemas(modelOperations);
+  await generateModelSchemas(models, modelOperations);
 }
 
 async function handleGeneratorOutputValue(generatorOutputValue: EnvValue) {
@@ -107,8 +107,12 @@ async function generateObjectSchemas(inputObjectTypes: DMMF.InputType[]) {
   }
 }
 
-async function generateModelSchemas(modelOperations: DMMF.ModelMapping[]) {
+async function generateModelSchemas(
+  models: DMMF.Model[],
+  modelOperations: DMMF.ModelMapping[],
+) {
   const transformer = new Transformer({
+    models,
     modelOperations,
   });
   await transformer.generateModelSchemas();

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type TransformerParams = {
   enumTypes?: PrismaDMMF.SchemaEnum[];
   fields?: PrismaDMMF.SchemaArg[];
   name?: string;
+  models?: PrismaDMMF.Model[];
   modelOperations?: PrismaDMMF.ModelMapping[];
   isDefaultPrismaClientOutput?: boolean;
   prismaClientOutputPath?: string;


### PR DESCRIPTION
### Description
**Original bug:** Include was being generated for models that do not have relations with other models. A prisma client type that does not exist was being referenced in the generated zod schema.

**Fix:** Include is only generated for models that have a relation with another model. The referenced prisma client type in the generated zod schema exists for these models.

I added a model to our schema.prisma that does not have a relation to any other models (Book). This will help us catch issues like this more easily in the future, as we do not currently have a model like this in the schema.prisma file. 

### References
Fixes issue: https://github.com/omar-dulaimi/prisma-zod-generator/issues/36
