### PR TITLE
Fix no array around createManyInput

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -552,7 +552,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateMany`,
-            `z.object({ data: ${modelName}CreateManyInputObjectSchema  })`,
+            `z.object({ data: z.array(${modelName}CreateManyInputObjectSchema) })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -552,7 +552,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateMany`,
-            `z.object({ data: z.array(${modelName}CreateManyInputObjectSchema) })`,
+            `z.object({ data: z.union([ ${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema) ]) })`,
           )}`,
         );
       }


### PR DESCRIPTION
### Description
Add `z.array()` on data property in `createMany<model>.schema.ts`.
This makes the zod schema conform to the prisma usage docs which requires a Enumerable around the input for createMany:
```
export type UserCreateManyArgs = {
  data: Enumerable<UserCreateManyInput>
  skipDuplicates?: boolean
}
```

### References
closes #50 
