### PR TITLE
fix: add missing "skipDuplicates" option to createMany input args

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -555,7 +555,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateMany`,
-            `z.object({ data: z.union([ ${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema) ]) })`,
+            `z.object({ data: z.union([ ${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema) ]), skipDuplicates: z.boolean().optional() })`,
           )}`,
         );
       }


### PR DESCRIPTION
### Description

Currently the zod output for `CreateMany` queries is only including the `data` property, but Prisma also allows `skipDuplicates`.

### References

**Prisma reference**

https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany

**Example output**

<img width="744" alt="Screenshot 2023-02-23 at 5 30 10 PM" src="https://user-images.githubusercontent.com/7423098/221055448-c30a90ef-f185-4495-9534-3dba0de175ad.png">
