### PR TITLE
Property hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ model User {
 }
 ```
 
+## Skipping properties
+
+```prisma
+model User {
+  id Int @id @default(autoincrement())
+  email String @unique
+  /// @@Gen.property(hide: true)
+  name String?
+}
+```
+
 # Additional Options
 
 | Option              | Description                                                                | Type      | Default       |

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,4 +47,7 @@ model Book {
 model Map {
   key   String @id
   value String
+
+  /// @@Gen.property(hide: true)
+  hiddenField String
 }


### PR DESCRIPTION
Please see the [contributing guidelines](https://github.com/omar-dulaimi/prisma-zod-generator/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description 

This PR adds a way of hiding properties of models using a doc string. The API is the same as hiding models, but uses `.property` instead of `.model` in the doc string.

Also, here's a list of the things done in this PR:

- Implements property hiding.
- Adds example of property hiding to the example Prisma schema file.
- Adds small documentation section in README for how to use this feature.

### References

Implements solution for #75