### PR TITLE
Use satisfies instead of type annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Automatically generate [Zod](https://github.com/colinhacks/zod) schemas from you
 - [Installation](#installing)
 - [Usage](#usage)
 - [Additional Options](#additional-options)
-- [Known Issues](#known-issues)
 
 # Supported Prisma Versions
 
@@ -120,8 +119,3 @@ generator zod {
   output     = "./generated-zod-schemas"
 }
 ```
-
-## Known Issues
-
-For the time being, fields that reference its parent schemas are not emitted. Like AND, OR, NOT.
-This is only temporary, as Zod make it hard to handle recursive types. https://github.com/colinhacks/zod#recursive-types

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ model Post {
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
+  likes     BigInt
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,17 +108,19 @@ app.post('/blog', async (req, res, next) => {
 
 ## Additional Options
 
-| Option             |  Description                                                             | Type      |  Default      |
-| ------------------ | ------------------------------------------------------------------------ | --------- | ------------- |
-| `output`           | Output directory for the generated zod schemas                           | `string`  | `./generated` |
-| `isGenerateSelect` | Enables the generation of Select related schemas and the select property | `boolean` | `false`       |
+| Option              | Description                                                                | Type      | Default       |
+| ------------------- | -------------------------------------------------------------------------- | --------- | ------------- |
+| `output`            | Output directory for the generated zod schemas                             | `string`  | `./generated` |
+| `isGenerateSelect`  | Enables the generation of Select related schemas and the select property   | `boolean` | `false`       |
+| `isGenerateInclude` | Enables the generation of Include related schemas and the include property | `boolean` | `false`       |
 
 Use additional options in the `schema.prisma`
 
 ```prisma
 generator zod {
-  provider   = "prisma-zod-generator"
-  output     = "./generated-zod-schemas"
-  isGenerateSelect = true
+  provider          = "prisma-zod-generator"
+  output            = "./generated-zod-schemas"
+  isGenerateSelect  = true
+  isGenerateInclude = true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ app.post('/blog', async (req, res, next) => {
 
 ## Additional Options
 
-| Option   |  Description                                   | Type     |  Default      |
-| -------- | ---------------------------------------------- | -------- | ------------- |
-| `output` | Output directory for the generated zod schemas | `string` | `./generated` |
+| Option             |  Description                                                             | Type      |  Default      |
+| ------------------ | ------------------------------------------------------------------------ | --------- | ------------- |
+| `output`           | Output directory for the generated zod schemas                           | `string`  | `./generated` |
+| `isGenerateSelect` | Enables the generation of Select related schemas and the select property | `boolean` | `false`       |
 
 Use additional options in the `schema.prisma`
 
@@ -118,5 +119,6 @@ Use additional options in the `schema.prisma`
 generator zod {
   provider   = "prisma-zod-generator"
   output     = "./generated-zod-schemas"
+  isGenerateSelect = true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Automatically generate [Zod](https://github.com/colinhacks/zod) schemas from you
 ## Table of Contents
 
 - [Supported Prisma Versions](#supported-prisma-versions)
-- [Installation](#installing)
+- [Installation](#installation)
 - [Usage](#usage)
 - [Customizations](#customizations)
 - [Additional Options](#additional-options)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Automatically generate [Zod](https://github.com/colinhacks/zod) schemas from you
 - [Supported Prisma Versions](#supported-prisma-versions)
 - [Installation](#installing)
 - [Usage](#usage)
+- [Customizations](#customizations)
 - [Additional Options](#additional-options)
 
 # Supported Prisma Versions
@@ -106,7 +107,20 @@ app.post('/blog', async (req, res, next) => {
 });
 ```
 
-## Additional Options
+# Customizations
+
+## Skipping entire models
+
+```prisma
+/// @@Gen.model(hide: true)
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+}
+```
+
+# Additional Options
 
 | Option              | Description                                                                | Type      | Default       |
 | ------------------- | -------------------------------------------------------------------------- | --------- | ------------- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.2.0",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,25 +6,25 @@
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@prisma/client": "^4.0.0",
-        "@prisma/generator-helper": "^4.0.0",
-        "@prisma/internals": "^4.0.0",
+        "@prisma/client": "^4.3.1",
+        "@prisma/generator-helper": "^4.3.1",
+        "@prisma/internals": "^4.3.1",
         "prettier": "^2.7.1",
         "tslib": "^2.4.0",
-        "zod": "^3.17.3"
+        "zod": "^3.18.0"
       },
       "bin": {
         "prisma-zod-generator": "lib/generator.js"
       },
       "devDependencies": {
-        "@types/node": "^18.0.3",
-        "@types/prettier": "^2.6.3",
-        "prisma": "^4.0.0",
-        "ts-node": "^10.8.2",
-        "typescript": "^4.7.4"
+        "@types/node": "^18.7.15",
+        "@types/prettier": "^2.7.0",
+        "prisma": "^4.3.1",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.8.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -192,13 +192,74 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
+      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.6.0.tgz",
+      "integrity": "sha512-07GlHuq72r2rnJugYVdGumviQvfrl8kEPidkZSVoseLVfIjV7nzxxt5/vqs9pK7JItWOrvjRdr/jTBVayFBr/w==",
+      "dependencies": {
+        "@opentelemetry/core": "1.6.0",
+        "@opentelemetry/semantic-conventions": "1.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.6.0.tgz",
+      "integrity": "sha512-yx/uuzHdT0QNRSEbCgXHc0GONk90uvaFcPGaNowIFSl85rTp4or4uIIMkG7R8ckj8xWjDSjsaztH6yQxoZrl5g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.6.0",
+        "@opentelemetry/resources": "1.6.0",
+        "@opentelemetry/semantic-conventions": "1.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@prisma/client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.0.0.tgz",
-      "integrity": "sha512-g1h2OGoRo7anBVQ9Cw3gsbjwPtvf7i0pkGxKeZICtwkvE5CZXW+xZF4FZdmrViYkKaAShbISL0teNpu9ecpf4g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.3.1.tgz",
+      "integrity": "sha512-FA0/d1VMJNWqzU7WVWTNWJ+lGOLR9JUBnF73GdIPAEVo/6dWk4gHx0EmgeU+SMv4MZoxgOeTBJF2azhg7x0hMw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+        "@prisma/engines-version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b"
       },
       "engines": {
         "node": ">=14.17"
@@ -213,9 +274,9 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.0.0.tgz",
-      "integrity": "sha512-3u+FEEwVSTXOkiWH+MEqy9T7VUrPxRZNKORKvuaJS1jL0bhDTCZOv7s/RsllVJRtEiAjWjy7il6Lj7DbQIiP0Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-rvDiWvChaKHZO4F9UFX/qG3jqYIYUbkWySAGJG0B9AMhw7k0EtjwYef02p/aLoz7smM3+ZPKJU9E+sqS1nympg==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -223,14 +284,16 @@
       }
     },
     "node_modules/@prisma/engine-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.0.0.tgz",
-      "integrity": "sha512-CH7F2TJpkgzp0UPk+la7fGVuxfvc5i7/xdegO+ZO2ipyDhTB/J47BCiA06U2T3/tfj9P9NeKZO4twPzt5fDjSw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.3.1.tgz",
+      "integrity": "sha512-Yirn3NUnzRKVW1C2cAGVdZi8yAyL6d4xLHkl+sbwJL6foS7UjTE0w5JEOwvkYDaPN5lf6Wo5Y8KFzb8f28BUyw==",
       "dependencies": {
-        "@prisma/debug": "4.0.0",
-        "@prisma/engines": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@prisma/generator-helper": "4.0.0",
-        "@prisma/get-platform": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
+        "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.4.0",
+        "@prisma/debug": "4.3.1",
+        "@prisma/engines": "4.3.1",
+        "@prisma/generator-helper": "4.3.1",
+        "@prisma/get-platform": "4.3.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -238,27 +301,27 @@
         "new-github-issue-url": "0.2.1",
         "p-retry": "4.6.2",
         "strip-ansi": "6.0.1",
-        "undici": "5.5.1"
+        "undici": "5.10.0"
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-u/rG4lDHALolWBLr3yebZ+N2qImp3SDMcu7bHNJuRDaYvYEXy/MqfNRNEgd9GoPsXL3gofYf0VzJf2AmCG3YVw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.3.1.tgz",
+      "integrity": "sha512-4JF/uMaEDAPdcdZNOrnzE3BvrbGpjgV0FcPT3EVoi6I86fWkloqqxBt+KcK/+fIRR0Pxj66uGR9wVH8U1Y13JA==",
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-PiZhdD624SrYEjyLboI0X7OugNbxUzDJx9v/6ldTKuqNDVUCmRH/Z00XwDi/dgM4FlqOSO+YiUsSiSKjxxG8cw=="
+      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
+      "integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-NszlDevAthYIEyw5z9G4V5N3fYiSXS9TWPLr4SO0iQIlKv3QVFbtxOwceOqXK2sxOIMlmGfpG2C4ifx4ok1THg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.3.1.tgz",
+      "integrity": "sha512-x1Dwth8pCQWnLGTRCPrk7hNIXikC/4HA+z27fny883rnP3Rn2OBzPTUe7xMc1qVoOTv955n8Siepo5h3g3qGJA==",
       "dependencies": {
-        "@prisma/debug": "3.15.2",
-        "@prisma/get-platform": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
+        "@prisma/debug": "4.3.1",
+        "@prisma/get-platform": "4.3.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -276,57 +339,37 @@
         "tempy": "1.0.1"
       }
     },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.15.2.tgz",
-      "integrity": "sha512-Uw6RkJmHolxXNifohIY9TIBRNWR2ciDY9LErPm6jymBs3mevLCUWm4m5AlyWyhKFWl0crUtwbAWE8Z79JiNRcw==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
     "node_modules/@prisma/generator-helper": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.0.0.tgz",
-      "integrity": "sha512-BuyfP1T+lGmvLsysKlFN12yNbVIJbtCm0lb+feIjCYwtFYVj3/+09wezLGzlaYPz+nnwqFohZrojcrBF0oBW8g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.3.1.tgz",
+      "integrity": "sha512-tWIfbpXG30nvxYhyp0MZj4RX/3B4dnYWj5i4hanK7yTTXt6oRBm4b1veYbC/nW1KcBbJvbp+zvLN0dDSmSldqQ==",
       "dependencies": {
-        "@prisma/debug": "4.0.0",
+        "@prisma/debug": "4.3.1",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-bq3Yn53Kd8UuqctoivfZ1XjS/Fwi3BIYw69Xl9A9MGSXZVgqWMy4REXS7qPh1o5HVGzUdhDXnRxuxez5iG7KEQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.3.1.tgz",
+      "integrity": "sha512-fK3WzQP2xN6vBXJFXrcjswoynCPC3iRe6FhlSCc1IE1ywEp2WHhLIYXyklaS61juCPGMMayGjCxSbFpQcV4kJw==",
       "dependencies": {
-        "@prisma/debug": "3.15.2"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.15.2.tgz",
-      "integrity": "sha512-Uw6RkJmHolxXNifohIY9TIBRNWR2ciDY9LErPm6jymBs3mevLCUWm4m5AlyWyhKFWl0crUtwbAWE8Z79JiNRcw==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
+        "@prisma/debug": "4.3.1"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.0.0.tgz",
-      "integrity": "sha512-ixXFOufIHWGgQ1BY8mseietiLqU4UuQDcsKiQdvr8lq6jkQNezoF6t63o7ClZkuhYB7sCQc1uxDvy9T26d8WTA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.3.1.tgz",
+      "integrity": "sha512-HsP/vlVwPKfQV2wkEoD+uvsOYmu1yADyjIhx2Tri3DvLBr3BQ9gX331TrlQbhhdeSXRCjsKmKGDlYUJ8MaPaJA==",
       "dependencies": {
-        "@prisma/debug": "4.0.0",
-        "@prisma/engine-core": "4.0.0",
-        "@prisma/engines": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@prisma/fetch-engine": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@prisma/generator-helper": "4.0.0",
-        "@prisma/get-platform": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@timsuchanek/copy": "1.4.5",
+        "@prisma/debug": "4.3.1",
+        "@prisma/engine-core": "4.3.1",
+        "@prisma/engines": "4.3.1",
+        "@prisma/fetch-engine": "4.3.1",
+        "@prisma/generator-helper": "4.3.1",
+        "@prisma/get-platform": "4.3.1",
+        "@prisma/prisma-fmt-wasm": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
@@ -336,7 +379,8 @@
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "find-up": "5.0.0",
-        "fp-ts": "2.12.1",
+        "fp-ts": "2.12.2",
+        "fs-extra": "10.1.0",
         "fs-jetpack": "4.3.1",
         "global-dirs": "3.0.0",
         "globby": "11.1.0",
@@ -355,11 +399,9 @@
         "replace-string": "3.1.0",
         "resolve": "1.22.1",
         "rimraf": "3.0.2",
-        "shell-quote": "1.7.3",
         "string-width": "4.2.3",
         "strip-ansi": "6.0.1",
         "strip-indent": "3.0.0",
-        "tar": "6.1.11",
         "temp-dir": "2.0.0",
         "temp-write": "4.0.0",
         "tempy": "1.0.1",
@@ -368,24 +410,10 @@
         "ts-pattern": "^4.0.1"
       }
     },
-    "node_modules/@timsuchanek/copy": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@timsuchanek/copy/-/copy-1.4.5.tgz",
-      "integrity": "sha512-N4+2/DvfwzQqHYL/scq07fv8yXbZc6RyUxKJoE8Clm14JpLOf9yNI4VB4D6RsV3h9zgzZ4loJUydHKM7pp3blw==",
-      "dependencies": {
-        "@timsuchanek/sleep-promise": "^8.0.1",
-        "commander": "^2.19.0",
-        "mkdirp": "^1.0.4",
-        "prettysize": "^2.0.0"
-      },
-      "bin": {
-        "node-copy": "cli.js"
-      }
-    },
-    "node_modules/@timsuchanek/sleep-promise": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@timsuchanek/sleep-promise/-/sleep-promise-8.0.1.tgz",
-      "integrity": "sha512-cxHYbrXfnCWsklydIHSw5GCMHUPqpJ/enxWSyVHNOgNe61sit/+aOXTTI+VOdWkvVaJsI2vsB9N4+YDNITawOQ=="
+    "node_modules/@prisma/prisma-fmt-wasm": {
+      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
+      "integrity": "sha512-65su522mHdxErZ7yIF/jd2/1gyj6lONpcpMchDUW+rWMCnqAjMXE3hxdmpdCetIV4Wfupgot1Uqd3GlMLU2y6g=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -441,9 +469,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
+      "version": "18.7.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
+      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -451,9 +479,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
-      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
       "dev": true
     },
     "node_modules/@types/retry": {
@@ -743,14 +771,6 @@
         "uuid": "8.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
@@ -824,11 +844,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -1162,14 +1177,27 @@
       }
     },
     "node_modules/fp-ts": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
-      "integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.2.tgz",
+      "integrity": "sha512-v8J7ud+nTkP5Zz17GhpCsY19wiRbB9miuj61nBcCJyDpu52zs9Z4O7OLDfYoKFQMJ9EsSZA7W1vRgC1d3jy5qw=="
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fs-jetpack": {
       "version": "4.3.1",
@@ -1189,17 +1217,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/fs.realpath": {
@@ -1589,6 +1606,17 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -1748,40 +1776,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -2093,19 +2087,14 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettysize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
-      "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg=="
-    },
     "node_modules/prisma": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.0.0.tgz",
-      "integrity": "sha512-Dtsar03XpCBkcEb2ooGWO/WcgblDTLzGhPcustbehwlFXuTMliMDRzXsfygsgYwQoZnAUKRd1rhpvBNEUziOVw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.3.1.tgz",
+      "integrity": "sha512-90xo06wtqil76Xsi3mNpc4Js3SdDRR5g4qb9h+4VWY4Y8iImJY6xc3PX+C9xxTSt1lr0Q89A0MLkJjd8ax6KiQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+        "@prisma/engines": "4.3.1"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -2354,11 +2343,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -2503,22 +2487,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -2646,9 +2614,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/ts-node": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
-      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -2713,9 +2681,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2726,9 +2694,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
       "engines": {
         "node": ">=12.18"
       }
@@ -2742,6 +2710,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -2813,11 +2789,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -2852,9 +2823,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2989,18 +2960,55 @@
         "fastq": "^1.6.0"
       }
     },
-    "@prisma/client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.0.0.tgz",
-      "integrity": "sha512-g1h2OGoRo7anBVQ9Cw3gsbjwPtvf7i0pkGxKeZICtwkvE5CZXW+xZF4FZdmrViYkKaAShbISL0teNpu9ecpf4g==",
+    "@opentelemetry/api": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
+      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g=="
+    },
+    "@opentelemetry/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
       "requires": {
-        "@prisma/engines-version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+        "@opentelemetry/semantic-conventions": "1.6.0"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.6.0.tgz",
+      "integrity": "sha512-07GlHuq72r2rnJugYVdGumviQvfrl8kEPidkZSVoseLVfIjV7nzxxt5/vqs9pK7JItWOrvjRdr/jTBVayFBr/w==",
+      "requires": {
+        "@opentelemetry/core": "1.6.0",
+        "@opentelemetry/semantic-conventions": "1.6.0"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.6.0.tgz",
+      "integrity": "sha512-yx/uuzHdT0QNRSEbCgXHc0GONk90uvaFcPGaNowIFSl85rTp4or4uIIMkG7R8ckj8xWjDSjsaztH6yQxoZrl5g==",
+      "requires": {
+        "@opentelemetry/core": "1.6.0",
+        "@opentelemetry/resources": "1.6.0",
+        "@opentelemetry/semantic-conventions": "1.6.0"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
+    },
+    "@prisma/client": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.3.1.tgz",
+      "integrity": "sha512-FA0/d1VMJNWqzU7WVWTNWJ+lGOLR9JUBnF73GdIPAEVo/6dWk4gHx0EmgeU+SMv4MZoxgOeTBJF2azhg7x0hMw==",
+      "requires": {
+        "@prisma/engines-version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b"
       }
     },
     "@prisma/debug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.0.0.tgz",
-      "integrity": "sha512-3u+FEEwVSTXOkiWH+MEqy9T7VUrPxRZNKORKvuaJS1jL0bhDTCZOv7s/RsllVJRtEiAjWjy7il6Lj7DbQIiP0Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-rvDiWvChaKHZO4F9UFX/qG3jqYIYUbkWySAGJG0B9AMhw7k0EtjwYef02p/aLoz7smM3+ZPKJU9E+sqS1nympg==",
       "requires": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -3008,14 +3016,16 @@
       }
     },
     "@prisma/engine-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.0.0.tgz",
-      "integrity": "sha512-CH7F2TJpkgzp0UPk+la7fGVuxfvc5i7/xdegO+ZO2ipyDhTB/J47BCiA06U2T3/tfj9P9NeKZO4twPzt5fDjSw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.3.1.tgz",
+      "integrity": "sha512-Yirn3NUnzRKVW1C2cAGVdZi8yAyL6d4xLHkl+sbwJL6foS7UjTE0w5JEOwvkYDaPN5lf6Wo5Y8KFzb8f28BUyw==",
       "requires": {
-        "@prisma/debug": "4.0.0",
-        "@prisma/engines": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@prisma/generator-helper": "4.0.0",
-        "@prisma/get-platform": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
+        "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.4.0",
+        "@prisma/debug": "4.3.1",
+        "@prisma/engines": "4.3.1",
+        "@prisma/generator-helper": "4.3.1",
+        "@prisma/get-platform": "4.3.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -3023,26 +3033,26 @@
         "new-github-issue-url": "0.2.1",
         "p-retry": "4.6.2",
         "strip-ansi": "6.0.1",
-        "undici": "5.5.1"
+        "undici": "5.10.0"
       }
     },
     "@prisma/engines": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-u/rG4lDHALolWBLr3yebZ+N2qImp3SDMcu7bHNJuRDaYvYEXy/MqfNRNEgd9GoPsXL3gofYf0VzJf2AmCG3YVw=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.3.1.tgz",
+      "integrity": "sha512-4JF/uMaEDAPdcdZNOrnzE3BvrbGpjgV0FcPT3EVoi6I86fWkloqqxBt+KcK/+fIRR0Pxj66uGR9wVH8U1Y13JA=="
     },
     "@prisma/engines-version": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-PiZhdD624SrYEjyLboI0X7OugNbxUzDJx9v/6ldTKuqNDVUCmRH/Z00XwDi/dgM4FlqOSO+YiUsSiSKjxxG8cw=="
+      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
+      "integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
     },
     "@prisma/fetch-engine": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-NszlDevAthYIEyw5z9G4V5N3fYiSXS9TWPLr4SO0iQIlKv3QVFbtxOwceOqXK2sxOIMlmGfpG2C4ifx4ok1THg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.3.1.tgz",
+      "integrity": "sha512-x1Dwth8pCQWnLGTRCPrk7hNIXikC/4HA+z27fny883rnP3Rn2OBzPTUe7xMc1qVoOTv955n8Siepo5h3g3qGJA==",
       "requires": {
-        "@prisma/debug": "3.15.2",
-        "@prisma/get-platform": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
+        "@prisma/debug": "4.3.1",
+        "@prisma/get-platform": "4.3.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -3058,63 +3068,39 @@
         "rimraf": "3.0.2",
         "temp-dir": "2.0.0",
         "tempy": "1.0.1"
-      },
-      "dependencies": {
-        "@prisma/debug": {
-          "version": "3.15.2",
-          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.15.2.tgz",
-          "integrity": "sha512-Uw6RkJmHolxXNifohIY9TIBRNWR2ciDY9LErPm6jymBs3mevLCUWm4m5AlyWyhKFWl0crUtwbAWE8Z79JiNRcw==",
-          "requires": {
-            "@types/debug": "4.1.7",
-            "debug": "4.3.4",
-            "strip-ansi": "6.0.1"
-          }
-        }
       }
     },
     "@prisma/generator-helper": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.0.0.tgz",
-      "integrity": "sha512-BuyfP1T+lGmvLsysKlFN12yNbVIJbtCm0lb+feIjCYwtFYVj3/+09wezLGzlaYPz+nnwqFohZrojcrBF0oBW8g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.3.1.tgz",
+      "integrity": "sha512-tWIfbpXG30nvxYhyp0MZj4RX/3B4dnYWj5i4hanK7yTTXt6oRBm4b1veYbC/nW1KcBbJvbp+zvLN0dDSmSldqQ==",
       "requires": {
-        "@prisma/debug": "4.0.0",
+        "@prisma/debug": "4.3.1",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "@prisma/get-platform": {
-      "version": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz",
-      "integrity": "sha512-bq3Yn53Kd8UuqctoivfZ1XjS/Fwi3BIYw69Xl9A9MGSXZVgqWMy4REXS7qPh1o5HVGzUdhDXnRxuxez5iG7KEQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.3.1.tgz",
+      "integrity": "sha512-fK3WzQP2xN6vBXJFXrcjswoynCPC3iRe6FhlSCc1IE1ywEp2WHhLIYXyklaS61juCPGMMayGjCxSbFpQcV4kJw==",
       "requires": {
-        "@prisma/debug": "3.15.2"
-      },
-      "dependencies": {
-        "@prisma/debug": {
-          "version": "3.15.2",
-          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.15.2.tgz",
-          "integrity": "sha512-Uw6RkJmHolxXNifohIY9TIBRNWR2ciDY9LErPm6jymBs3mevLCUWm4m5AlyWyhKFWl0crUtwbAWE8Z79JiNRcw==",
-          "requires": {
-            "@types/debug": "4.1.7",
-            "debug": "4.3.4",
-            "strip-ansi": "6.0.1"
-          }
-        }
+        "@prisma/debug": "4.3.1"
       }
     },
     "@prisma/internals": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.0.0.tgz",
-      "integrity": "sha512-ixXFOufIHWGgQ1BY8mseietiLqU4UuQDcsKiQdvr8lq6jkQNezoF6t63o7ClZkuhYB7sCQc1uxDvy9T26d8WTA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.3.1.tgz",
+      "integrity": "sha512-HsP/vlVwPKfQV2wkEoD+uvsOYmu1yADyjIhx2Tri3DvLBr3BQ9gX331TrlQbhhdeSXRCjsKmKGDlYUJ8MaPaJA==",
       "requires": {
-        "@prisma/debug": "4.0.0",
-        "@prisma/engine-core": "4.0.0",
-        "@prisma/engines": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@prisma/fetch-engine": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@prisma/generator-helper": "4.0.0",
-        "@prisma/get-platform": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11",
-        "@timsuchanek/copy": "1.4.5",
+        "@prisma/debug": "4.3.1",
+        "@prisma/engine-core": "4.3.1",
+        "@prisma/engines": "4.3.1",
+        "@prisma/fetch-engine": "4.3.1",
+        "@prisma/generator-helper": "4.3.1",
+        "@prisma/get-platform": "4.3.1",
+        "@prisma/prisma-fmt-wasm": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
@@ -3124,7 +3110,8 @@
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "find-up": "5.0.0",
-        "fp-ts": "2.12.1",
+        "fp-ts": "2.12.2",
+        "fs-extra": "10.1.0",
         "fs-jetpack": "4.3.1",
         "global-dirs": "3.0.0",
         "globby": "11.1.0",
@@ -3143,11 +3130,9 @@
         "replace-string": "3.1.0",
         "resolve": "1.22.1",
         "rimraf": "3.0.2",
-        "shell-quote": "1.7.3",
         "string-width": "4.2.3",
         "strip-ansi": "6.0.1",
         "strip-indent": "3.0.0",
-        "tar": "6.1.11",
         "temp-dir": "2.0.0",
         "temp-write": "4.0.0",
         "tempy": "1.0.1",
@@ -3156,21 +3141,10 @@
         "ts-pattern": "^4.0.1"
       }
     },
-    "@timsuchanek/copy": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@timsuchanek/copy/-/copy-1.4.5.tgz",
-      "integrity": "sha512-N4+2/DvfwzQqHYL/scq07fv8yXbZc6RyUxKJoE8Clm14JpLOf9yNI4VB4D6RsV3h9zgzZ4loJUydHKM7pp3blw==",
-      "requires": {
-        "@timsuchanek/sleep-promise": "^8.0.1",
-        "commander": "^2.19.0",
-        "mkdirp": "^1.0.4",
-        "prettysize": "^2.0.0"
-      }
-    },
-    "@timsuchanek/sleep-promise": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@timsuchanek/sleep-promise/-/sleep-promise-8.0.1.tgz",
-      "integrity": "sha512-cxHYbrXfnCWsklydIHSw5GCMHUPqpJ/enxWSyVHNOgNe61sit/+aOXTTI+VOdWkvVaJsI2vsB9N4+YDNITawOQ=="
+    "@prisma/prisma-fmt-wasm": {
+      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
+      "integrity": "sha512-65su522mHdxErZ7yIF/jd2/1gyj6lONpcpMchDUW+rWMCnqAjMXE3hxdmpdCetIV4Wfupgot1Uqd3GlMLU2y6g=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -3223,9 +3197,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
+      "version": "18.7.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
+      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3233,9 +3207,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/prettier": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
-      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
       "dev": true
     },
     "@types/retry": {
@@ -3441,11 +3415,6 @@
         "uuid": "8.3.2"
       }
     },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-    },
     "ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
@@ -3495,11 +3464,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -3745,14 +3709,24 @@
       }
     },
     "fp-ts": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
-      "integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.2.tgz",
+      "integrity": "sha512-v8J7ud+nTkP5Zz17GhpCsY19wiRbB9miuj61nBcCJyDpu52zs9Z4O7OLDfYoKFQMJ9EsSZA7W1vRgC1d3jy5qw=="
     },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "fs-jetpack": {
       "version": "4.3.1",
@@ -3771,14 +3745,6 @@
             "glob": "^7.1.3"
           }
         }
-      }
-    },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "requires": {
-        "minipass": "^3.0.0"
       }
     },
     "fs.realpath": {
@@ -4040,6 +4006,15 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4166,28 +4141,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minipass": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "ms": {
       "version": "2.1.3",
@@ -4397,18 +4350,13 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
-    "prettysize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
-      "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg=="
-    },
     "prisma": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.0.0.tgz",
-      "integrity": "sha512-Dtsar03XpCBkcEb2ooGWO/WcgblDTLzGhPcustbehwlFXuTMliMDRzXsfygsgYwQoZnAUKRd1rhpvBNEUziOVw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.3.1.tgz",
+      "integrity": "sha512-90xo06wtqil76Xsi3mNpc4Js3SdDRR5g4qb9h+4VWY4Y8iImJY6xc3PX+C9xxTSt1lr0Q89A0MLkJjd8ax6KiQ==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+        "@prisma/engines": "4.3.1"
       }
     },
     "process-nextick-args": {
@@ -4565,11 +4513,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
-    "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
-    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4684,19 +4627,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
-    "tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      }
-    },
     "tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -4788,9 +4718,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "ts-node": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
-      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -4832,15 +4762,15 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true
     },
     "undici": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
     },
     "unique-string": {
       "version": "2.0.0",
@@ -4849,6 +4779,11 @@
       "requires": {
         "crypto-random-string": "^2.0.0"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -4910,11 +4845,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -4937,9 +4867,9 @@
       }
     },
     "zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,30 +28,30 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -94,12 +94,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -107,7 +107,7 @@
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
       }
@@ -136,18 +136,18 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -193,73 +193,73 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.6.0.tgz",
-      "integrity": "sha512-07GlHuq72r2rnJugYVdGumviQvfrl8kEPidkZSVoseLVfIjV7nzxxt5/vqs9pK7JItWOrvjRdr/jTBVayFBr/w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
+      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "dependencies": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.6.0.tgz",
-      "integrity": "sha512-yx/uuzHdT0QNRSEbCgXHc0GONk90uvaFcPGaNowIFSl85rTp4or4uIIMkG7R8ckj8xWjDSjsaztH6yQxoZrl5g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
+      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "dependencies": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/resources": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.3.1.tgz",
-      "integrity": "sha512-FA0/d1VMJNWqzU7WVWTNWJ+lGOLR9JUBnF73GdIPAEVo/6dWk4gHx0EmgeU+SMv4MZoxgOeTBJF2azhg7x0hMw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.6.1.tgz",
+      "integrity": "sha512-M1+NNrMzqaOIxT7PBGcTs3IZo7d1EW/+gVQd4C4gUgWBDGgD9AcIeZnUSidgWClmpMSgVUdnVORjsWWGUameYA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b"
+        "@prisma/engines-version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32"
       },
       "engines": {
         "node": ">=14.17"
@@ -274,9 +274,9 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-rvDiWvChaKHZO4F9UFX/qG3jqYIYUbkWySAGJG0B9AMhw7k0EtjwYef02p/aLoz7smM3+ZPKJU9E+sqS1nympg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.6.1.tgz",
+      "integrity": "sha512-BezDvSenTgQDQ6WA3TdTDGcrt0Oh4vmpZtmSOYm1KaSZiSVIL2xT0P9TFM3vtOa4wn7sn/003PyTSxyHS3mShg==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -284,16 +284,16 @@
       }
     },
     "node_modules/@prisma/engine-core": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.3.1.tgz",
-      "integrity": "sha512-Yirn3NUnzRKVW1C2cAGVdZi8yAyL6d4xLHkl+sbwJL6foS7UjTE0w5JEOwvkYDaPN5lf6Wo5Y8KFzb8f28BUyw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.6.1.tgz",
+      "integrity": "sha512-JtvdEy9GeGU/xeTYOq3SEN4DiAytHoQty/4pJTZ5vNoGMnu7XF1ToprOCPzyT5oSgm3oQQuwpXMVaebJegwA4Q==",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
-        "@prisma/debug": "4.3.1",
-        "@prisma/engines": "4.3.1",
-        "@prisma/generator-helper": "4.3.1",
-        "@prisma/get-platform": "4.3.1",
+        "@prisma/debug": "4.6.1",
+        "@prisma/engines": "4.6.1",
+        "@prisma/generator-helper": "4.6.1",
+        "@prisma/get-platform": "4.6.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -301,27 +301,27 @@
         "new-github-issue-url": "0.2.1",
         "p-retry": "4.6.2",
         "strip-ansi": "6.0.1",
-        "undici": "5.10.0"
+        "undici": "5.11.0"
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.3.1.tgz",
-      "integrity": "sha512-4JF/uMaEDAPdcdZNOrnzE3BvrbGpjgV0FcPT3EVoi6I86fWkloqqxBt+KcK/+fIRR0Pxj66uGR9wVH8U1Y13JA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.6.1.tgz",
+      "integrity": "sha512-3u2/XxvxB+Q7cMXHnKU0CpBiUK1QWqpgiBv28YDo1zOIJE3FCF8DI2vrp6vuwjGt5h0JGXDSvmSf4D4maVjJdw==",
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
-      "integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
+      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
+      "integrity": "sha512-HUCmkXAU2jqp2O1RvNtbE+seLGLyJGEABZS/R38rZjSAafAy0WzBuHq+tbZMnD+b5OSCsTVtIPVcuvx1ySxcWQ=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.3.1.tgz",
-      "integrity": "sha512-x1Dwth8pCQWnLGTRCPrk7hNIXikC/4HA+z27fny883rnP3Rn2OBzPTUe7xMc1qVoOTv955n8Siepo5h3g3qGJA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.6.1.tgz",
+      "integrity": "sha512-0Nggqzd6J630wO65i5LjyYxarHSZL3mlN04j98Eff5tzhymwv6A8QEMMwuIJY3B5mQ+3ns3q6zZsJ3Ef063RUA==",
       "dependencies": {
-        "@prisma/debug": "4.3.1",
-        "@prisma/get-platform": "4.3.1",
+        "@prisma/debug": "4.6.1",
+        "@prisma/get-platform": "4.6.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -340,52 +340,51 @@
       }
     },
     "node_modules/@prisma/generator-helper": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.3.1.tgz",
-      "integrity": "sha512-tWIfbpXG30nvxYhyp0MZj4RX/3B4dnYWj5i4hanK7yTTXt6oRBm4b1veYbC/nW1KcBbJvbp+zvLN0dDSmSldqQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.6.1.tgz",
+      "integrity": "sha512-70XBmqDhmpe8H35ttOJOgyg1OpppO/uelILB1SIwjeSI7PHHdU2+Y/+LkpnifkCEpSZKIhxEIPbHx17m2neAsA==",
       "dependencies": {
-        "@prisma/debug": "4.3.1",
+        "@prisma/debug": "4.6.1",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.3.1.tgz",
-      "integrity": "sha512-fK3WzQP2xN6vBXJFXrcjswoynCPC3iRe6FhlSCc1IE1ywEp2WHhLIYXyklaS61juCPGMMayGjCxSbFpQcV4kJw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.6.1.tgz",
+      "integrity": "sha512-JBlzN53Q00bTfk3mPxeprAx8LLN7bmEwTGZ3fFjbCKZACsHtbDaaqtIkqXwk0tv1jJ3jLYZfcq7NlvdOPyJhGw==",
       "dependencies": {
-        "@prisma/debug": "4.3.1"
+        "@prisma/debug": "4.6.1"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.3.1.tgz",
-      "integrity": "sha512-HsP/vlVwPKfQV2wkEoD+uvsOYmu1yADyjIhx2Tri3DvLBr3BQ9gX331TrlQbhhdeSXRCjsKmKGDlYUJ8MaPaJA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.6.1.tgz",
+      "integrity": "sha512-oPE01UMMY5W9PAr+uP0MaHO4o7SD3b7dVqaEuZsj6NRN7jtoKujQXp+zo74BAeqjLJyCiHXhTIReuO9NExiZtg==",
       "dependencies": {
-        "@prisma/debug": "4.3.1",
-        "@prisma/engine-core": "4.3.1",
-        "@prisma/engines": "4.3.1",
-        "@prisma/fetch-engine": "4.3.1",
-        "@prisma/generator-helper": "4.3.1",
-        "@prisma/get-platform": "4.3.1",
-        "@prisma/prisma-fmt-wasm": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
+        "@prisma/debug": "4.6.1",
+        "@prisma/engine-core": "4.6.1",
+        "@prisma/engines": "4.6.1",
+        "@prisma/fetch-engine": "4.6.1",
+        "@prisma/generator-helper": "4.6.1",
+        "@prisma/get-platform": "4.6.1",
+        "@prisma/prisma-fmt-wasm": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
         "checkpoint-client": "1.1.21",
         "cli-truncate": "2.1.0",
-        "dotenv": "16.0.1",
+        "dotenv": "16.0.3",
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "find-up": "5.0.0",
-        "fp-ts": "2.12.2",
+        "fp-ts": "2.13.1",
         "fs-extra": "10.1.0",
-        "fs-jetpack": "4.3.1",
+        "fs-jetpack": "5.1.0",
         "global-dirs": "3.0.0",
         "globby": "11.1.0",
         "has-yarn": "2.1.0",
-        "is-ci": "3.0.1",
         "is-windows": "^1.0.2",
         "is-wsl": "^2.2.0",
         "make-dir": "3.1.0",
@@ -411,9 +410,9 @@
       }
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
-      "integrity": "sha512-65su522mHdxErZ7yIF/jd2/1gyj6lONpcpMchDUW+rWMCnqAjMXE3hxdmpdCetIV4Wfupgot1Uqd3GlMLU2y6g=="
+      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
+      "integrity": "sha512-hT+YRaH5NTZDYhLhSKMUdtY+i8sKkjjFwiDYhy6688G+H8oFklIwPNeApKH8Jw5bbtuH6onIzo1oivapOFJryg=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -424,27 +423,27 @@
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true
     },
     "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "node_modules/@types/cross-spawn": {
@@ -469,9 +468,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
-      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -479,9 +478,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
-      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
     "node_modules/@types/retry": {
@@ -490,9 +489,9 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -631,6 +630,19 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -653,9 +665,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -692,12 +704,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -737,9 +748,20 @@
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/chalk": {
@@ -796,9 +818,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
       "engines": {
         "node": ">=6"
       },
@@ -824,7 +846,7 @@
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "engines": {
         "node": ">=0.8"
       }
@@ -867,7 +889,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -946,11 +968,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/del": {
@@ -995,9 +1020,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
       }
@@ -1065,9 +1090,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1134,52 +1159,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/find-up/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fp-ts": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.2.tgz",
-      "integrity": "sha512-v8J7ud+nTkP5Zz17GhpCsY19wiRbB9miuj61nBcCJyDpu52zs9Z4O7OLDfYoKFQMJ9EsSZA7W1vRgC1d3jy5qw=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
+      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -1200,29 +1183,17 @@
       }
     },
     "node_modules/fs-jetpack": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
-      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-5.1.0.tgz",
+      "integrity": "sha512-Xn4fDhLydXkuzepZVsr02jakLlmoARPy+YWIclo4kh0GyNGUHnTqeH/w/qIsVn50dFxtp8otPL2t/HcPJBbxUA==",
       "dependencies": {
-        "minimatch": "^3.0.2",
-        "rimraf": "^2.6.3"
-      }
-    },
-    "node_modules/fs-jetpack/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "minimatch": "^5.1.0"
       }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1241,14 +1212,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -1268,6 +1239,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/global-dirs": {
@@ -1408,9 +1399,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
       "engines": {
         "node": ">= 4"
       }
@@ -1426,7 +1417,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1448,23 +1439,12 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -1589,12 +1569,12 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1650,46 +1630,62 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1768,14 +1764,14 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -1851,7 +1847,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
       }
@@ -1927,28 +1923,31 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -2013,7 +2012,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2073,10 +2072,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -2088,13 +2123,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.3.1.tgz",
-      "integrity": "sha512-90xo06wtqil76Xsi3mNpc4Js3SdDRR5g4qb9h+4VWY4Y8iImJY6xc3PX+C9xxTSt1lr0Q89A0MLkJjd8ax6KiQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.6.1.tgz",
+      "integrity": "sha512-BR4itMCuzrDV4tn3e2TF+nh1zIX/RVU0isKtKoN28ADeoJ9nYaMhiuRRkFd2TZN8+l/XfYzoRKyHzUFXLQhmBQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.3.1"
+        "@prisma/engines": "4.6.1"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -2190,6 +2225,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -2212,11 +2283,11 @@
       }
     },
     "node_modules/readdir-glob": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
-      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.2.tgz",
+      "integrity": "sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==",
       "dependencies": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.1.0"
       }
     },
     "node_modules/replace-string": {
@@ -2312,9 +2383,23 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -2398,16 +2483,24 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -2465,9 +2558,9 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -2528,7 +2621,7 @@
     "node_modules/temp-write/node_modules/temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
       "engines": {
         "node": ">=4"
       }
@@ -2611,7 +2704,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -2663,14 +2756,14 @@
       "dev": true
     },
     "node_modules/ts-pattern": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.0.2.tgz",
-      "integrity": "sha512-eHqR/7A6fcw05vCOfnL6RwgGJbVi9G/YHTdYdjYmElhDdJ1SMn7pWs+6+YuxygaFwQS/g+cIDlu+UD8IVpur1A=="
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.0.6.tgz",
+      "integrity": "sha512-sFHQYD4KoysBi7e7a2mzDPvRBeqA4w+vEyRE+P5MU9VLq8eEYxgKCgD9RNEAT+itGRWUTYN+hry94GDPLb1/Yw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-fest": {
       "version": "0.8.1",
@@ -2681,9 +2774,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2694,9 +2787,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
+      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
       "engines": {
         "node": ">=12.18"
       }
@@ -2723,7 +2819,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -2751,7 +2847,7 @@
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -2759,12 +2855,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -2787,7 +2883,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yn": {
       "version": "3.1.1",
@@ -2823,9 +2919,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
-      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2833,24 +2929,24 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/highlight": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -2884,17 +2980,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
@@ -2916,15 +3012,15 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
@@ -2961,54 +3057,54 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
     },
     "@opentelemetry/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.6.0.tgz",
-      "integrity": "sha512-07GlHuq72r2rnJugYVdGumviQvfrl8kEPidkZSVoseLVfIjV7nzxxt5/vqs9pK7JItWOrvjRdr/jTBVayFBr/w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
+      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "requires": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.6.0.tgz",
-      "integrity": "sha512-yx/uuzHdT0QNRSEbCgXHc0GONk90uvaFcPGaNowIFSl85rTp4or4uIIMkG7R8ckj8xWjDSjsaztH6yQxoZrl5g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
+      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "requires": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/resources": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
     },
     "@prisma/client": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.3.1.tgz",
-      "integrity": "sha512-FA0/d1VMJNWqzU7WVWTNWJ+lGOLR9JUBnF73GdIPAEVo/6dWk4gHx0EmgeU+SMv4MZoxgOeTBJF2azhg7x0hMw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.6.1.tgz",
+      "integrity": "sha512-M1+NNrMzqaOIxT7PBGcTs3IZo7d1EW/+gVQd4C4gUgWBDGgD9AcIeZnUSidgWClmpMSgVUdnVORjsWWGUameYA==",
       "requires": {
-        "@prisma/engines-version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b"
+        "@prisma/engines-version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32"
       }
     },
     "@prisma/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-rvDiWvChaKHZO4F9UFX/qG3jqYIYUbkWySAGJG0B9AMhw7k0EtjwYef02p/aLoz7smM3+ZPKJU9E+sqS1nympg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.6.1.tgz",
+      "integrity": "sha512-BezDvSenTgQDQ6WA3TdTDGcrt0Oh4vmpZtmSOYm1KaSZiSVIL2xT0P9TFM3vtOa4wn7sn/003PyTSxyHS3mShg==",
       "requires": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -3016,16 +3112,16 @@
       }
     },
     "@prisma/engine-core": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.3.1.tgz",
-      "integrity": "sha512-Yirn3NUnzRKVW1C2cAGVdZi8yAyL6d4xLHkl+sbwJL6foS7UjTE0w5JEOwvkYDaPN5lf6Wo5Y8KFzb8f28BUyw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.6.1.tgz",
+      "integrity": "sha512-JtvdEy9GeGU/xeTYOq3SEN4DiAytHoQty/4pJTZ5vNoGMnu7XF1ToprOCPzyT5oSgm3oQQuwpXMVaebJegwA4Q==",
       "requires": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
-        "@prisma/debug": "4.3.1",
-        "@prisma/engines": "4.3.1",
-        "@prisma/generator-helper": "4.3.1",
-        "@prisma/get-platform": "4.3.1",
+        "@prisma/debug": "4.6.1",
+        "@prisma/engines": "4.6.1",
+        "@prisma/generator-helper": "4.6.1",
+        "@prisma/get-platform": "4.6.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -3033,26 +3129,26 @@
         "new-github-issue-url": "0.2.1",
         "p-retry": "4.6.2",
         "strip-ansi": "6.0.1",
-        "undici": "5.10.0"
+        "undici": "5.11.0"
       }
     },
     "@prisma/engines": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.3.1.tgz",
-      "integrity": "sha512-4JF/uMaEDAPdcdZNOrnzE3BvrbGpjgV0FcPT3EVoi6I86fWkloqqxBt+KcK/+fIRR0Pxj66uGR9wVH8U1Y13JA=="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.6.1.tgz",
+      "integrity": "sha512-3u2/XxvxB+Q7cMXHnKU0CpBiUK1QWqpgiBv28YDo1zOIJE3FCF8DI2vrp6vuwjGt5h0JGXDSvmSf4D4maVjJdw=="
     },
     "@prisma/engines-version": {
-      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
-      "integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
+      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
+      "integrity": "sha512-HUCmkXAU2jqp2O1RvNtbE+seLGLyJGEABZS/R38rZjSAafAy0WzBuHq+tbZMnD+b5OSCsTVtIPVcuvx1ySxcWQ=="
     },
     "@prisma/fetch-engine": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.3.1.tgz",
-      "integrity": "sha512-x1Dwth8pCQWnLGTRCPrk7hNIXikC/4HA+z27fny883rnP3Rn2OBzPTUe7xMc1qVoOTv955n8Siepo5h3g3qGJA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.6.1.tgz",
+      "integrity": "sha512-0Nggqzd6J630wO65i5LjyYxarHSZL3mlN04j98Eff5tzhymwv6A8QEMMwuIJY3B5mQ+3ns3q6zZsJ3Ef063RUA==",
       "requires": {
-        "@prisma/debug": "4.3.1",
-        "@prisma/get-platform": "4.3.1",
+        "@prisma/debug": "4.6.1",
+        "@prisma/get-platform": "4.6.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -3071,52 +3167,51 @@
       }
     },
     "@prisma/generator-helper": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.3.1.tgz",
-      "integrity": "sha512-tWIfbpXG30nvxYhyp0MZj4RX/3B4dnYWj5i4hanK7yTTXt6oRBm4b1veYbC/nW1KcBbJvbp+zvLN0dDSmSldqQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.6.1.tgz",
+      "integrity": "sha512-70XBmqDhmpe8H35ttOJOgyg1OpppO/uelILB1SIwjeSI7PHHdU2+Y/+LkpnifkCEpSZKIhxEIPbHx17m2neAsA==",
       "requires": {
-        "@prisma/debug": "4.3.1",
+        "@prisma/debug": "4.6.1",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "@prisma/get-platform": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.3.1.tgz",
-      "integrity": "sha512-fK3WzQP2xN6vBXJFXrcjswoynCPC3iRe6FhlSCc1IE1ywEp2WHhLIYXyklaS61juCPGMMayGjCxSbFpQcV4kJw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.6.1.tgz",
+      "integrity": "sha512-JBlzN53Q00bTfk3mPxeprAx8LLN7bmEwTGZ3fFjbCKZACsHtbDaaqtIkqXwk0tv1jJ3jLYZfcq7NlvdOPyJhGw==",
       "requires": {
-        "@prisma/debug": "4.3.1"
+        "@prisma/debug": "4.6.1"
       }
     },
     "@prisma/internals": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.3.1.tgz",
-      "integrity": "sha512-HsP/vlVwPKfQV2wkEoD+uvsOYmu1yADyjIhx2Tri3DvLBr3BQ9gX331TrlQbhhdeSXRCjsKmKGDlYUJ8MaPaJA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.6.1.tgz",
+      "integrity": "sha512-oPE01UMMY5W9PAr+uP0MaHO4o7SD3b7dVqaEuZsj6NRN7jtoKujQXp+zo74BAeqjLJyCiHXhTIReuO9NExiZtg==",
       "requires": {
-        "@prisma/debug": "4.3.1",
-        "@prisma/engine-core": "4.3.1",
-        "@prisma/engines": "4.3.1",
-        "@prisma/fetch-engine": "4.3.1",
-        "@prisma/generator-helper": "4.3.1",
-        "@prisma/get-platform": "4.3.1",
-        "@prisma/prisma-fmt-wasm": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
+        "@prisma/debug": "4.6.1",
+        "@prisma/engine-core": "4.6.1",
+        "@prisma/engines": "4.6.1",
+        "@prisma/fetch-engine": "4.6.1",
+        "@prisma/generator-helper": "4.6.1",
+        "@prisma/get-platform": "4.6.1",
+        "@prisma/prisma-fmt-wasm": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
         "checkpoint-client": "1.1.21",
         "cli-truncate": "2.1.0",
-        "dotenv": "16.0.1",
+        "dotenv": "16.0.3",
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "find-up": "5.0.0",
-        "fp-ts": "2.12.2",
+        "fp-ts": "2.13.1",
         "fs-extra": "10.1.0",
-        "fs-jetpack": "4.3.1",
+        "fs-jetpack": "5.1.0",
         "global-dirs": "3.0.0",
         "globby": "11.1.0",
         "has-yarn": "2.1.0",
-        "is-ci": "3.0.1",
         "is-windows": "^1.0.2",
         "is-wsl": "^2.2.0",
         "make-dir": "3.1.0",
@@ -3142,9 +3237,9 @@
       }
     },
     "@prisma/prisma-fmt-wasm": {
-      "version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
-      "integrity": "sha512-65su522mHdxErZ7yIF/jd2/1gyj6lONpcpMchDUW+rWMCnqAjMXE3hxdmpdCetIV4Wfupgot1Uqd3GlMLU2y6g=="
+      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
+      "integrity": "sha512-hT+YRaH5NTZDYhLhSKMUdtY+i8sKkjjFwiDYhy6688G+H8oFklIwPNeApKH8Jw5bbtuH6onIzo1oivapOFJryg=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -3152,27 +3247,27 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
     },
     "@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true
     },
     "@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/cross-spawn": {
@@ -3197,9 +3292,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.7.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
-      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3207,9 +3302,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/prettier": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
-      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
     "@types/retry": {
@@ -3218,9 +3313,9 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true
     },
     "acorn-walk": {
@@ -3318,6 +3413,19 @@
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
@@ -3337,9 +3445,9 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -3362,12 +3470,11 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "braces": {
@@ -3390,7 +3497,15 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -3434,9 +3549,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw=="
     },
     "cli-truncate": {
       "version": "2.1.0",
@@ -3450,7 +3565,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -3484,7 +3599,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -3542,9 +3657,9 @@
       }
     },
     "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "requires": {
         "clone": "^1.0.2"
       }
@@ -3579,9 +3694,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -3631,9 +3746,9 @@
       }
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3680,38 +3795,12 @@
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
-      },
-      "dependencies": {
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        }
       }
     },
     "fp-ts": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.2.tgz",
-      "integrity": "sha512-v8J7ud+nTkP5Zz17GhpCsY19wiRbB9miuj61nBcCJyDpu52zs9Z4O7OLDfYoKFQMJ9EsSZA7W1vRgC1d3jy5qw=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
+      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -3729,28 +3818,17 @@
       }
     },
     "fs-jetpack": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz",
-      "integrity": "sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-5.1.0.tgz",
+      "integrity": "sha512-Xn4fDhLydXkuzepZVsr02jakLlmoARPy+YWIclo4kh0GyNGUHnTqeH/w/qIsVn50dFxtp8otPL2t/HcPJBbxUA==",
       "requires": {
-        "minimatch": "^3.0.2",
-        "rimraf": "^2.6.3"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
+        "minimatch": "^5.1.0"
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3763,16 +3841,35 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -3871,9 +3968,9 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA=="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -3883,7 +3980,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3902,20 +3999,12 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "requires": {
-        "ci-info": "^3.2.0"
-      }
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -3989,12 +4078,12 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4041,6 +4130,19 @@
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
@@ -4050,37 +4152,37 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "requires": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       }
     },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -4135,11 +4237,11 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       }
     },
     "ms": {
@@ -4194,7 +4296,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -4248,19 +4350,19 @@
       }
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "requires": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
       }
     },
     "p-map": {
@@ -4304,7 +4406,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -4342,21 +4444,45 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
         }
       }
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
     },
     "prisma": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.3.1.tgz",
-      "integrity": "sha512-90xo06wtqil76Xsi3mNpc4Js3SdDRR5g4qb9h+4VWY4Y8iImJY6xc3PX+C9xxTSt1lr0Q89A0MLkJjd8ax6KiQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.6.1.tgz",
+      "integrity": "sha512-BR4itMCuzrDV4tn3e2TF+nh1zIX/RVU0isKtKoN28ADeoJ9nYaMhiuRRkFd2TZN8+l/XfYzoRKyHzUFXLQhmBQ==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.3.1"
+        "@prisma/engines": "4.6.1"
       }
     },
     "process-nextick-args": {
@@ -4419,6 +4545,30 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
         }
       }
     },
@@ -4433,11 +4583,11 @@
       }
     },
     "readdir-glob": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
-      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.2.tgz",
+      "integrity": "sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.1.0"
       }
     },
     "replace-string": {
@@ -4491,9 +4641,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
       "version": "6.3.0",
@@ -4562,16 +4712,21 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
@@ -4614,9 +4769,9 @@
       }
     },
     "supports-hyperlinks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -4659,7 +4814,7 @@
         "temp-dir": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-          "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+          "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ=="
         },
         "uuid": {
           "version": "3.4.0",
@@ -4715,7 +4870,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "ts-node": {
       "version": "10.9.1",
@@ -4747,14 +4902,14 @@
       }
     },
     "ts-pattern": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.0.2.tgz",
-      "integrity": "sha512-eHqR/7A6fcw05vCOfnL6RwgGJbVi9G/YHTdYdjYmElhDdJ1SMn7pWs+6+YuxygaFwQS/g+cIDlu+UD8IVpur1A=="
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.0.6.tgz",
+      "integrity": "sha512-sFHQYD4KoysBi7e7a2mzDPvRBeqA4w+vEyRE+P5MU9VLq8eEYxgKCgD9RNEAT+itGRWUTYN+hry94GDPLb1/Yw=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-fest": {
       "version": "0.8.1",
@@ -4762,15 +4917,18 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "undici": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
+      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unique-string": {
       "version": "2.0.0",
@@ -4788,7 +4946,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "8.3.2",
@@ -4813,7 +4971,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "requires": {
         "defaults": "^1.0.3"
       }
@@ -4821,12 +4979,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4843,7 +5001,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "yn": {
       "version": "3.1.1",
@@ -4867,9 +5025,9 @@
       }
     },
     "zod": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
-      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA=="
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,22 @@
       "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
-        "@prisma/client": "^4.3.1",
-        "@prisma/generator-helper": "^4.3.1",
-        "@prisma/internals": "^4.3.1",
-        "prettier": "^2.7.1",
-        "tslib": "^2.4.0",
-        "zod": "^3.18.0"
+        "@prisma/client": "^4.8.0",
+        "@prisma/generator-helper": "^4.8.0",
+        "@prisma/internals": "^4.8.0",
+        "prettier": "^2.8.1",
+        "tslib": "^2.4.1",
+        "zod": "^3.20.2"
       },
       "bin": {
         "prisma-zod-generator": "lib/generator.js"
       },
       "devDependencies": {
-        "@types/node": "^18.7.15",
-        "@types/prettier": "^2.7.0",
-        "prisma": "^4.3.1",
+        "@types/node": "^18.11.18",
+        "@types/prettier": "^2.7.2",
+        "prisma": "^4.8.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.8.2"
+        "typescript": "^4.9.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -469,9 +469,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3294,9 +3294,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,12 +254,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.7.0.tgz",
-      "integrity": "sha512-keXMa0oJWJGOzMEFKp+CEgzJPwnOtGSrnTWw6qMYxnypYrRFdNxqyA06EzELZexBhgM4oLooZ1jDJ3iy46wExA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.8.0.tgz",
+      "integrity": "sha512-Y1riB0p2W52kh3zgssP/YAhln3RjBFcJy3uwEiyjmU+TQYh6QTZDRFBo3JtBWuq2FyMOl1Rye8jxzUP+n0l5Cg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635"
+        "@prisma/engines-version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
       },
       "engines": {
         "node": ">=14.17"
@@ -274,9 +274,9 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.7.1.tgz",
-      "integrity": "sha512-oppjBRcTakJuAn0rANxWT9caxLKypSBT4Ajh7t+uPcO06CJOoN2Gt4VpFdw2i79U+klGAjTe/1yh8SCsTmxAhA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.8.0.tgz",
+      "integrity": "sha512-/VT+P6npte5nN8RgLUYm7cNFpHnl7WxbPRZDUIbMF6FG1oI2i3I3NOSOM05urdd1X/rjlZWUgxoh7rL2sdaLSQ==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -284,16 +284,16 @@
       }
     },
     "node_modules/@prisma/engine-core": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.7.1.tgz",
-      "integrity": "sha512-8NwCQcdB4OqOjpehChtKdVn6UVuDTwZewnRG13aeK+KmZurPqGO1LhwB3dTjlfLRlbYsLGb3Xzsai7Jl5QckBA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.8.0.tgz",
+      "integrity": "sha512-No9Bj0+MKb5LaKPhDqRoXwP00LpTXiBAhrRjAy71wW2sen33r3PmYi+y7njhXUyqm2bUTdYvwO5/CHrv7IdWsw==",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
-        "@prisma/debug": "4.7.1",
-        "@prisma/engines": "4.7.1",
-        "@prisma/generator-helper": "4.7.1",
-        "@prisma/get-platform": "4.7.1",
+        "@prisma/debug": "4.8.0",
+        "@prisma/engines": "4.8.0",
+        "@prisma/generator-helper": "4.8.0",
+        "@prisma/get-platform": "4.8.0",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -305,23 +305,23 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.1.tgz",
-      "integrity": "sha512-zWabHosTdLpXXlMefHmnouhXMoTB1+SCbUU3t4FCmdrtIOZcarPKU3Alto7gm/pZ9vHlGOXHCfVZ1G7OIrSbog==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.0.tgz",
+      "integrity": "sha512-A1Asn2rxZMlLAj1HTyfaCv0VQrLUv034jVay05QlqZg1qiHPeA3/pGTfNMijbsMYCsGVxfWEJuaZZuNxXGMCrA==",
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635.tgz",
-      "integrity": "sha512-ImczGEQ8NS1OUApEeyAGxC4uLTtQp0wI1+2wM4MeQLVwIQbyMHk1vOhWWE8Pwbi3rnzLcPvsIrd9sm6oNXhERw=="
+      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
+      "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.7.1.tgz",
-      "integrity": "sha512-pZ3SiUV02FTMBJOwzoqGR4YcZ2jTo43Xw1QC/5YwmRkYa5NPydUnap5rvB84DgVNq5OnOrQxhWSsakOUPqcc6g==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.8.0.tgz",
+      "integrity": "sha512-7GjQNSsNkfKNRAgwNAaqjHTWLjCoA9vLUZuq3VmApdhFfUeXX8vFIJrnBE3xxHNpo0iSJj/ap4GCQmSrFs+beg==",
       "dependencies": {
-        "@prisma/debug": "4.7.1",
-        "@prisma/get-platform": "4.7.1",
+        "@prisma/debug": "4.8.0",
+        "@prisma/get-platform": "4.8.0",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -340,36 +340,37 @@
       }
     },
     "node_modules/@prisma/generator-helper": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.7.1.tgz",
-      "integrity": "sha512-q9mjYOyLxkLWhqjvPB5sx5J1VRegWA2eC9mwrGgA0CSMo6SzZ7xwIe4rMJKnh4a7QMUO03+HQFdv/Nz7BOWCcg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.8.0.tgz",
+      "integrity": "sha512-qUSX/6aLkIXUAnIw5IyJdizkqFYYc4EfP4VFLAFYQb281affP6XNQm8nf+El7H6J4MM0eWPRqTH1gtAWFqAYkg==",
       "dependencies": {
-        "@prisma/debug": "4.7.1",
+        "@prisma/debug": "4.8.0",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.7.1.tgz",
-      "integrity": "sha512-p160ToD9j53TgSrg0O0q3GkGZTGwB30UqIu3B0bu/NIvhnhHOwuEo4tyDXYKblLOE2TL0e1t0PWOSQAvH3nKYw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.8.0.tgz",
+      "integrity": "sha512-5laip4xTO8yW9Xv8NqJtv4MVB/2RarfaGTChnMIqr3LJvXRSxoAnC4ticLvjxoA1gtbko3tm8hQl+WPEdK04UQ==",
       "dependencies": {
-        "@prisma/debug": "4.7.1"
+        "@prisma/debug": "4.8.0",
+        "ts-pattern": "4.0.6"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.7.1.tgz",
-      "integrity": "sha512-YgG+5zLZuKdVUPnNdw9XA0XGfW1vZaOqrcGgRnla0mSIIIB3Gg3noRuHv9ZQAXeHLWh2v7MHxal6fxKElMN0ug==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.8.0.tgz",
+      "integrity": "sha512-QUqNhPjM9+B4KQhzoR/C7Cns9v1e/K8ef9lk7XTXGVoZX/7PZnjRXv8qtW3oyyUzPhfkM6Wc1DQ+49rj4VSYfw==",
       "dependencies": {
-        "@prisma/debug": "4.7.1",
-        "@prisma/engine-core": "4.7.1",
-        "@prisma/engines": "4.7.1",
-        "@prisma/fetch-engine": "4.7.1",
-        "@prisma/generator-helper": "4.7.1",
-        "@prisma/get-platform": "4.7.1",
-        "@prisma/prisma-fmt-wasm": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
+        "@prisma/debug": "4.8.0",
+        "@prisma/engine-core": "4.8.0",
+        "@prisma/engines": "4.8.0",
+        "@prisma/fetch-engine": "4.8.0",
+        "@prisma/generator-helper": "4.8.0",
+        "@prisma/get-platform": "4.8.0",
+        "@prisma/prisma-fmt-wasm": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
@@ -380,7 +381,7 @@
         "execa": "5.1.1",
         "find-up": "5.0.0",
         "fp-ts": "2.13.1",
-        "fs-extra": "10.1.0",
+        "fs-extra": "11.1.0",
         "fs-jetpack": "5.1.0",
         "global-dirs": "3.0.0",
         "globby": "11.1.0",
@@ -410,9 +411,9 @@
       }
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c.tgz",
-      "integrity": "sha512-o9oSp2c5yDWHn9TT2Ntv3cb6LuJKPBy32gTtipYH1D166KfKBy+1RkPySobWZCKV/TrkUGlcBn5vcQgRBHPvVA=="
+      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
+      "integrity": "sha512-0/X9/6R4HudrfYjKmQXMMckXJ61eZnWLpc8K3rdCWCJPki+9Jzjw7dTM7A2LG3lx/UMiSnLvM4o+/mBVqeBPGg=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -468,9 +469,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -478,9 +479,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
+      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
     "node_modules/@types/retry": {
@@ -1110,9 +1111,9 @@
       "integrity": "sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw=="
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1170,16 +1171,16 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-jetpack": {
@@ -1399,9 +1400,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
-      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -1764,9 +1765,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2109,9 +2110,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -2123,13 +2124,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.7.0.tgz",
-      "integrity": "sha512-VsecNo0Ca3+bDTzSpJqIpdupKVhhQ8aOYeWc09JlUM89knqvhSrlMrg0U8BiOD4tFrY1OPaCcraK8leDBxKMBg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.8.0.tgz",
+      "integrity": "sha512-DWIhxvxt8f4h6MDd35mz7BJff+fu7HItW3WPDIEpCR3RzcOWyiHBbLQW5/DOgmf+pRLTjwXQob7kuTZVYUAw5w==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.7.0"
+        "@prisma/engines": "4.8.0"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -2138,13 +2139,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/prisma/node_modules/@prisma/engines": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.0.tgz",
-      "integrity": "sha512-afKrVFktaZ1pOK12/uFl2hRsBWIJZuC5FdDtacuKk5x/mR+rC5AbA+PlN3ZCZbmYTaeiBMHjcU5wbT5z2N3nSQ==",
-      "devOptional": true,
-      "hasInstallScript": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -2781,9 +2775,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2926,9 +2920,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3101,17 +3095,17 @@
       "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
     },
     "@prisma/client": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.7.0.tgz",
-      "integrity": "sha512-keXMa0oJWJGOzMEFKp+CEgzJPwnOtGSrnTWw6qMYxnypYrRFdNxqyA06EzELZexBhgM4oLooZ1jDJ3iy46wExA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.8.0.tgz",
+      "integrity": "sha512-Y1riB0p2W52kh3zgssP/YAhln3RjBFcJy3uwEiyjmU+TQYh6QTZDRFBo3JtBWuq2FyMOl1Rye8jxzUP+n0l5Cg==",
       "requires": {
-        "@prisma/engines-version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635"
+        "@prisma/engines-version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
       }
     },
     "@prisma/debug": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.7.1.tgz",
-      "integrity": "sha512-oppjBRcTakJuAn0rANxWT9caxLKypSBT4Ajh7t+uPcO06CJOoN2Gt4VpFdw2i79U+klGAjTe/1yh8SCsTmxAhA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.8.0.tgz",
+      "integrity": "sha512-/VT+P6npte5nN8RgLUYm7cNFpHnl7WxbPRZDUIbMF6FG1oI2i3I3NOSOM05urdd1X/rjlZWUgxoh7rL2sdaLSQ==",
       "requires": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -3119,16 +3113,16 @@
       }
     },
     "@prisma/engine-core": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.7.1.tgz",
-      "integrity": "sha512-8NwCQcdB4OqOjpehChtKdVn6UVuDTwZewnRG13aeK+KmZurPqGO1LhwB3dTjlfLRlbYsLGb3Xzsai7Jl5QckBA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.8.0.tgz",
+      "integrity": "sha512-No9Bj0+MKb5LaKPhDqRoXwP00LpTXiBAhrRjAy71wW2sen33r3PmYi+y7njhXUyqm2bUTdYvwO5/CHrv7IdWsw==",
       "requires": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
-        "@prisma/debug": "4.7.1",
-        "@prisma/engines": "4.7.1",
-        "@prisma/generator-helper": "4.7.1",
-        "@prisma/get-platform": "4.7.1",
+        "@prisma/debug": "4.8.0",
+        "@prisma/engines": "4.8.0",
+        "@prisma/generator-helper": "4.8.0",
+        "@prisma/get-platform": "4.8.0",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -3140,22 +3134,22 @@
       }
     },
     "@prisma/engines": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.1.tgz",
-      "integrity": "sha512-zWabHosTdLpXXlMefHmnouhXMoTB1+SCbUU3t4FCmdrtIOZcarPKU3Alto7gm/pZ9vHlGOXHCfVZ1G7OIrSbog=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.0.tgz",
+      "integrity": "sha512-A1Asn2rxZMlLAj1HTyfaCv0VQrLUv034jVay05QlqZg1qiHPeA3/pGTfNMijbsMYCsGVxfWEJuaZZuNxXGMCrA=="
     },
     "@prisma/engines-version": {
-      "version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635.tgz",
-      "integrity": "sha512-ImczGEQ8NS1OUApEeyAGxC4uLTtQp0wI1+2wM4MeQLVwIQbyMHk1vOhWWE8Pwbi3rnzLcPvsIrd9sm6oNXhERw=="
+      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
+      "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
     },
     "@prisma/fetch-engine": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.7.1.tgz",
-      "integrity": "sha512-pZ3SiUV02FTMBJOwzoqGR4YcZ2jTo43Xw1QC/5YwmRkYa5NPydUnap5rvB84DgVNq5OnOrQxhWSsakOUPqcc6g==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.8.0.tgz",
+      "integrity": "sha512-7GjQNSsNkfKNRAgwNAaqjHTWLjCoA9vLUZuq3VmApdhFfUeXX8vFIJrnBE3xxHNpo0iSJj/ap4GCQmSrFs+beg==",
       "requires": {
-        "@prisma/debug": "4.7.1",
-        "@prisma/get-platform": "4.7.1",
+        "@prisma/debug": "4.8.0",
+        "@prisma/get-platform": "4.8.0",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -3174,36 +3168,37 @@
       }
     },
     "@prisma/generator-helper": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.7.1.tgz",
-      "integrity": "sha512-q9mjYOyLxkLWhqjvPB5sx5J1VRegWA2eC9mwrGgA0CSMo6SzZ7xwIe4rMJKnh4a7QMUO03+HQFdv/Nz7BOWCcg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.8.0.tgz",
+      "integrity": "sha512-qUSX/6aLkIXUAnIw5IyJdizkqFYYc4EfP4VFLAFYQb281affP6XNQm8nf+El7H6J4MM0eWPRqTH1gtAWFqAYkg==",
       "requires": {
-        "@prisma/debug": "4.7.1",
+        "@prisma/debug": "4.8.0",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "@prisma/get-platform": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.7.1.tgz",
-      "integrity": "sha512-p160ToD9j53TgSrg0O0q3GkGZTGwB30UqIu3B0bu/NIvhnhHOwuEo4tyDXYKblLOE2TL0e1t0PWOSQAvH3nKYw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.8.0.tgz",
+      "integrity": "sha512-5laip4xTO8yW9Xv8NqJtv4MVB/2RarfaGTChnMIqr3LJvXRSxoAnC4ticLvjxoA1gtbko3tm8hQl+WPEdK04UQ==",
       "requires": {
-        "@prisma/debug": "4.7.1"
+        "@prisma/debug": "4.8.0",
+        "ts-pattern": "4.0.6"
       }
     },
     "@prisma/internals": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.7.1.tgz",
-      "integrity": "sha512-YgG+5zLZuKdVUPnNdw9XA0XGfW1vZaOqrcGgRnla0mSIIIB3Gg3noRuHv9ZQAXeHLWh2v7MHxal6fxKElMN0ug==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.8.0.tgz",
+      "integrity": "sha512-QUqNhPjM9+B4KQhzoR/C7Cns9v1e/K8ef9lk7XTXGVoZX/7PZnjRXv8qtW3oyyUzPhfkM6Wc1DQ+49rj4VSYfw==",
       "requires": {
-        "@prisma/debug": "4.7.1",
-        "@prisma/engine-core": "4.7.1",
-        "@prisma/engines": "4.7.1",
-        "@prisma/fetch-engine": "4.7.1",
-        "@prisma/generator-helper": "4.7.1",
-        "@prisma/get-platform": "4.7.1",
-        "@prisma/prisma-fmt-wasm": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
+        "@prisma/debug": "4.8.0",
+        "@prisma/engine-core": "4.8.0",
+        "@prisma/engines": "4.8.0",
+        "@prisma/fetch-engine": "4.8.0",
+        "@prisma/generator-helper": "4.8.0",
+        "@prisma/get-platform": "4.8.0",
+        "@prisma/prisma-fmt-wasm": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
@@ -3214,7 +3209,7 @@
         "execa": "5.1.1",
         "find-up": "5.0.0",
         "fp-ts": "2.13.1",
-        "fs-extra": "10.1.0",
+        "fs-extra": "11.1.0",
         "fs-jetpack": "5.1.0",
         "global-dirs": "3.0.0",
         "globby": "11.1.0",
@@ -3244,9 +3239,9 @@
       }
     },
     "@prisma/prisma-fmt-wasm": {
-      "version": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c.tgz",
-      "integrity": "sha512-o9oSp2c5yDWHn9TT2Ntv3cb6LuJKPBy32gTtipYH1D166KfKBy+1RkPySobWZCKV/TrkUGlcBn5vcQgRBHPvVA=="
+      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
+      "integrity": "sha512-0/X9/6R4HudrfYjKmQXMMckXJ61eZnWLpc8K3rdCWCJPki+9Jzjw7dTM7A2LG3lx/UMiSnLvM4o+/mBVqeBPGg=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -3299,9 +3294,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3309,9 +3304,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
+      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
     "@types/retry": {
@@ -3770,9 +3765,9 @@
       "integrity": "sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw=="
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -3815,9 +3810,9 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3975,9 +3970,9 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
-      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA=="
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -4244,9 +4239,9 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }
@@ -4479,25 +4474,17 @@
       }
     },
     "prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg=="
     },
     "prisma": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.7.0.tgz",
-      "integrity": "sha512-VsecNo0Ca3+bDTzSpJqIpdupKVhhQ8aOYeWc09JlUM89knqvhSrlMrg0U8BiOD4tFrY1OPaCcraK8leDBxKMBg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.8.0.tgz",
+      "integrity": "sha512-DWIhxvxt8f4h6MDd35mz7BJff+fu7HItW3WPDIEpCR3RzcOWyiHBbLQW5/DOgmf+pRLTjwXQob7kuTZVYUAw5w==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.7.0"
-      },
-      "dependencies": {
-        "@prisma/engines": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.0.tgz",
-          "integrity": "sha512-afKrVFktaZ1pOK12/uFl2hRsBWIJZuC5FdDtacuKk5x/mR+rC5AbA+PlN3ZCZbmYTaeiBMHjcU5wbT5z2N3nSQ==",
-          "devOptional": true
-        }
+        "@prisma/engines": "4.8.0"
       }
     },
     "process-nextick-args": {
@@ -4932,9 +4919,9 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "undici": {
@@ -5040,9 +5027,9 @@
       }
     },
     "zod": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,12 +254,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.6.1.tgz",
-      "integrity": "sha512-M1+NNrMzqaOIxT7PBGcTs3IZo7d1EW/+gVQd4C4gUgWBDGgD9AcIeZnUSidgWClmpMSgVUdnVORjsWWGUameYA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.7.0.tgz",
+      "integrity": "sha512-keXMa0oJWJGOzMEFKp+CEgzJPwnOtGSrnTWw6qMYxnypYrRFdNxqyA06EzELZexBhgM4oLooZ1jDJ3iy46wExA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32"
+        "@prisma/engines-version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635"
       },
       "engines": {
         "node": ">=14.17"
@@ -274,9 +274,9 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.6.1.tgz",
-      "integrity": "sha512-BezDvSenTgQDQ6WA3TdTDGcrt0Oh4vmpZtmSOYm1KaSZiSVIL2xT0P9TFM3vtOa4wn7sn/003PyTSxyHS3mShg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.7.1.tgz",
+      "integrity": "sha512-oppjBRcTakJuAn0rANxWT9caxLKypSBT4Ajh7t+uPcO06CJOoN2Gt4VpFdw2i79U+klGAjTe/1yh8SCsTmxAhA==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -284,16 +284,16 @@
       }
     },
     "node_modules/@prisma/engine-core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.6.1.tgz",
-      "integrity": "sha512-JtvdEy9GeGU/xeTYOq3SEN4DiAytHoQty/4pJTZ5vNoGMnu7XF1ToprOCPzyT5oSgm3oQQuwpXMVaebJegwA4Q==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.7.1.tgz",
+      "integrity": "sha512-8NwCQcdB4OqOjpehChtKdVn6UVuDTwZewnRG13aeK+KmZurPqGO1LhwB3dTjlfLRlbYsLGb3Xzsai7Jl5QckBA==",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
-        "@prisma/debug": "4.6.1",
-        "@prisma/engines": "4.6.1",
-        "@prisma/generator-helper": "4.6.1",
-        "@prisma/get-platform": "4.6.1",
+        "@prisma/debug": "4.7.1",
+        "@prisma/engines": "4.7.1",
+        "@prisma/generator-helper": "4.7.1",
+        "@prisma/get-platform": "4.7.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -305,23 +305,23 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.6.1.tgz",
-      "integrity": "sha512-3u2/XxvxB+Q7cMXHnKU0CpBiUK1QWqpgiBv28YDo1zOIJE3FCF8DI2vrp6vuwjGt5h0JGXDSvmSf4D4maVjJdw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.1.tgz",
+      "integrity": "sha512-zWabHosTdLpXXlMefHmnouhXMoTB1+SCbUU3t4FCmdrtIOZcarPKU3Alto7gm/pZ9vHlGOXHCfVZ1G7OIrSbog==",
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
-      "integrity": "sha512-HUCmkXAU2jqp2O1RvNtbE+seLGLyJGEABZS/R38rZjSAafAy0WzBuHq+tbZMnD+b5OSCsTVtIPVcuvx1ySxcWQ=="
+      "version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635.tgz",
+      "integrity": "sha512-ImczGEQ8NS1OUApEeyAGxC4uLTtQp0wI1+2wM4MeQLVwIQbyMHk1vOhWWE8Pwbi3rnzLcPvsIrd9sm6oNXhERw=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.6.1.tgz",
-      "integrity": "sha512-0Nggqzd6J630wO65i5LjyYxarHSZL3mlN04j98Eff5tzhymwv6A8QEMMwuIJY3B5mQ+3ns3q6zZsJ3Ef063RUA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.7.1.tgz",
+      "integrity": "sha512-pZ3SiUV02FTMBJOwzoqGR4YcZ2jTo43Xw1QC/5YwmRkYa5NPydUnap5rvB84DgVNq5OnOrQxhWSsakOUPqcc6g==",
       "dependencies": {
-        "@prisma/debug": "4.6.1",
-        "@prisma/get-platform": "4.6.1",
+        "@prisma/debug": "4.7.1",
+        "@prisma/get-platform": "4.7.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -340,36 +340,36 @@
       }
     },
     "node_modules/@prisma/generator-helper": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.6.1.tgz",
-      "integrity": "sha512-70XBmqDhmpe8H35ttOJOgyg1OpppO/uelILB1SIwjeSI7PHHdU2+Y/+LkpnifkCEpSZKIhxEIPbHx17m2neAsA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.7.1.tgz",
+      "integrity": "sha512-q9mjYOyLxkLWhqjvPB5sx5J1VRegWA2eC9mwrGgA0CSMo6SzZ7xwIe4rMJKnh4a7QMUO03+HQFdv/Nz7BOWCcg==",
       "dependencies": {
-        "@prisma/debug": "4.6.1",
+        "@prisma/debug": "4.7.1",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.6.1.tgz",
-      "integrity": "sha512-JBlzN53Q00bTfk3mPxeprAx8LLN7bmEwTGZ3fFjbCKZACsHtbDaaqtIkqXwk0tv1jJ3jLYZfcq7NlvdOPyJhGw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.7.1.tgz",
+      "integrity": "sha512-p160ToD9j53TgSrg0O0q3GkGZTGwB30UqIu3B0bu/NIvhnhHOwuEo4tyDXYKblLOE2TL0e1t0PWOSQAvH3nKYw==",
       "dependencies": {
-        "@prisma/debug": "4.6.1"
+        "@prisma/debug": "4.7.1"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.6.1.tgz",
-      "integrity": "sha512-oPE01UMMY5W9PAr+uP0MaHO4o7SD3b7dVqaEuZsj6NRN7jtoKujQXp+zo74BAeqjLJyCiHXhTIReuO9NExiZtg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.7.1.tgz",
+      "integrity": "sha512-YgG+5zLZuKdVUPnNdw9XA0XGfW1vZaOqrcGgRnla0mSIIIB3Gg3noRuHv9ZQAXeHLWh2v7MHxal6fxKElMN0ug==",
       "dependencies": {
-        "@prisma/debug": "4.6.1",
-        "@prisma/engine-core": "4.6.1",
-        "@prisma/engines": "4.6.1",
-        "@prisma/fetch-engine": "4.6.1",
-        "@prisma/generator-helper": "4.6.1",
-        "@prisma/get-platform": "4.6.1",
-        "@prisma/prisma-fmt-wasm": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
+        "@prisma/debug": "4.7.1",
+        "@prisma/engine-core": "4.7.1",
+        "@prisma/engines": "4.7.1",
+        "@prisma/fetch-engine": "4.7.1",
+        "@prisma/generator-helper": "4.7.1",
+        "@prisma/get-platform": "4.7.1",
+        "@prisma/prisma-fmt-wasm": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
-      "integrity": "sha512-hT+YRaH5NTZDYhLhSKMUdtY+i8sKkjjFwiDYhy6688G+H8oFklIwPNeApKH8Jw5bbtuH6onIzo1oivapOFJryg=="
+      "version": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c.tgz",
+      "integrity": "sha512-o9oSp2c5yDWHn9TT2Ntv3cb6LuJKPBy32gTtipYH1D166KfKBy+1RkPySobWZCKV/TrkUGlcBn5vcQgRBHPvVA=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -468,9 +468,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
+      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1764,9 +1764,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2123,13 +2123,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.6.1.tgz",
-      "integrity": "sha512-BR4itMCuzrDV4tn3e2TF+nh1zIX/RVU0isKtKoN28ADeoJ9nYaMhiuRRkFd2TZN8+l/XfYzoRKyHzUFXLQhmBQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.7.0.tgz",
+      "integrity": "sha512-VsecNo0Ca3+bDTzSpJqIpdupKVhhQ8aOYeWc09JlUM89knqvhSrlMrg0U8BiOD4tFrY1OPaCcraK8leDBxKMBg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.6.1"
+        "@prisma/engines": "4.7.0"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -2138,6 +2138,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/prisma/node_modules/@prisma/engines": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.0.tgz",
+      "integrity": "sha512-afKrVFktaZ1pOK12/uFl2hRsBWIJZuC5FdDtacuKk5x/mR+rC5AbA+PlN3ZCZbmYTaeiBMHjcU5wbT5z2N3nSQ==",
+      "devOptional": true,
+      "hasInstallScript": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -3094,17 +3101,17 @@
       "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
     },
     "@prisma/client": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.6.1.tgz",
-      "integrity": "sha512-M1+NNrMzqaOIxT7PBGcTs3IZo7d1EW/+gVQd4C4gUgWBDGgD9AcIeZnUSidgWClmpMSgVUdnVORjsWWGUameYA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.7.0.tgz",
+      "integrity": "sha512-keXMa0oJWJGOzMEFKp+CEgzJPwnOtGSrnTWw6qMYxnypYrRFdNxqyA06EzELZexBhgM4oLooZ1jDJ3iy46wExA==",
       "requires": {
-        "@prisma/engines-version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32"
+        "@prisma/engines-version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635"
       }
     },
     "@prisma/debug": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.6.1.tgz",
-      "integrity": "sha512-BezDvSenTgQDQ6WA3TdTDGcrt0Oh4vmpZtmSOYm1KaSZiSVIL2xT0P9TFM3vtOa4wn7sn/003PyTSxyHS3mShg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.7.1.tgz",
+      "integrity": "sha512-oppjBRcTakJuAn0rANxWT9caxLKypSBT4Ajh7t+uPcO06CJOoN2Gt4VpFdw2i79U+klGAjTe/1yh8SCsTmxAhA==",
       "requires": {
         "@types/debug": "4.1.7",
         "debug": "4.3.4",
@@ -3112,16 +3119,16 @@
       }
     },
     "@prisma/engine-core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.6.1.tgz",
-      "integrity": "sha512-JtvdEy9GeGU/xeTYOq3SEN4DiAytHoQty/4pJTZ5vNoGMnu7XF1ToprOCPzyT5oSgm3oQQuwpXMVaebJegwA4Q==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-4.7.1.tgz",
+      "integrity": "sha512-8NwCQcdB4OqOjpehChtKdVn6UVuDTwZewnRG13aeK+KmZurPqGO1LhwB3dTjlfLRlbYsLGb3Xzsai7Jl5QckBA==",
       "requires": {
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/sdk-trace-base": "^1.4.0",
-        "@prisma/debug": "4.6.1",
-        "@prisma/engines": "4.6.1",
-        "@prisma/generator-helper": "4.6.1",
-        "@prisma/get-platform": "4.6.1",
+        "@prisma/debug": "4.7.1",
+        "@prisma/engines": "4.7.1",
+        "@prisma/generator-helper": "4.7.1",
+        "@prisma/get-platform": "4.7.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -3133,22 +3140,22 @@
       }
     },
     "@prisma/engines": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.6.1.tgz",
-      "integrity": "sha512-3u2/XxvxB+Q7cMXHnKU0CpBiUK1QWqpgiBv28YDo1zOIJE3FCF8DI2vrp6vuwjGt5h0JGXDSvmSf4D4maVjJdw=="
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.1.tgz",
+      "integrity": "sha512-zWabHosTdLpXXlMefHmnouhXMoTB1+SCbUU3t4FCmdrtIOZcarPKU3Alto7gm/pZ9vHlGOXHCfVZ1G7OIrSbog=="
     },
     "@prisma/engines-version": {
-      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
-      "integrity": "sha512-HUCmkXAU2jqp2O1RvNtbE+seLGLyJGEABZS/R38rZjSAafAy0WzBuHq+tbZMnD+b5OSCsTVtIPVcuvx1ySxcWQ=="
+      "version": "4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.7.0-74.39190b250ebc338586e25e6da45e5e783bc8a635.tgz",
+      "integrity": "sha512-ImczGEQ8NS1OUApEeyAGxC4uLTtQp0wI1+2wM4MeQLVwIQbyMHk1vOhWWE8Pwbi3rnzLcPvsIrd9sm6oNXhERw=="
     },
     "@prisma/fetch-engine": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.6.1.tgz",
-      "integrity": "sha512-0Nggqzd6J630wO65i5LjyYxarHSZL3mlN04j98Eff5tzhymwv6A8QEMMwuIJY3B5mQ+3ns3q6zZsJ3Ef063RUA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.7.1.tgz",
+      "integrity": "sha512-pZ3SiUV02FTMBJOwzoqGR4YcZ2jTo43Xw1QC/5YwmRkYa5NPydUnap5rvB84DgVNq5OnOrQxhWSsakOUPqcc6g==",
       "requires": {
-        "@prisma/debug": "4.6.1",
-        "@prisma/get-platform": "4.6.1",
+        "@prisma/debug": "4.7.1",
+        "@prisma/get-platform": "4.7.1",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
@@ -3167,36 +3174,36 @@
       }
     },
     "@prisma/generator-helper": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.6.1.tgz",
-      "integrity": "sha512-70XBmqDhmpe8H35ttOJOgyg1OpppO/uelILB1SIwjeSI7PHHdU2+Y/+LkpnifkCEpSZKIhxEIPbHx17m2neAsA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.7.1.tgz",
+      "integrity": "sha512-q9mjYOyLxkLWhqjvPB5sx5J1VRegWA2eC9mwrGgA0CSMo6SzZ7xwIe4rMJKnh4a7QMUO03+HQFdv/Nz7BOWCcg==",
       "requires": {
-        "@prisma/debug": "4.6.1",
+        "@prisma/debug": "4.7.1",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "@prisma/get-platform": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.6.1.tgz",
-      "integrity": "sha512-JBlzN53Q00bTfk3mPxeprAx8LLN7bmEwTGZ3fFjbCKZACsHtbDaaqtIkqXwk0tv1jJ3jLYZfcq7NlvdOPyJhGw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.7.1.tgz",
+      "integrity": "sha512-p160ToD9j53TgSrg0O0q3GkGZTGwB30UqIu3B0bu/NIvhnhHOwuEo4tyDXYKblLOE2TL0e1t0PWOSQAvH3nKYw==",
       "requires": {
-        "@prisma/debug": "4.6.1"
+        "@prisma/debug": "4.7.1"
       }
     },
     "@prisma/internals": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.6.1.tgz",
-      "integrity": "sha512-oPE01UMMY5W9PAr+uP0MaHO4o7SD3b7dVqaEuZsj6NRN7jtoKujQXp+zo74BAeqjLJyCiHXhTIReuO9NExiZtg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.7.1.tgz",
+      "integrity": "sha512-YgG+5zLZuKdVUPnNdw9XA0XGfW1vZaOqrcGgRnla0mSIIIB3Gg3noRuHv9ZQAXeHLWh2v7MHxal6fxKElMN0ug==",
       "requires": {
-        "@prisma/debug": "4.6.1",
-        "@prisma/engine-core": "4.6.1",
-        "@prisma/engines": "4.6.1",
-        "@prisma/fetch-engine": "4.6.1",
-        "@prisma/generator-helper": "4.6.1",
-        "@prisma/get-platform": "4.6.1",
-        "@prisma/prisma-fmt-wasm": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
+        "@prisma/debug": "4.7.1",
+        "@prisma/engine-core": "4.7.1",
+        "@prisma/engines": "4.7.1",
+        "@prisma/fetch-engine": "4.7.1",
+        "@prisma/generator-helper": "4.7.1",
+        "@prisma/get-platform": "4.7.1",
+        "@prisma/prisma-fmt-wasm": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "chalk": "4.1.2",
@@ -3237,9 +3244,9 @@
       }
     },
     "@prisma/prisma-fmt-wasm": {
-      "version": "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz",
-      "integrity": "sha512-hT+YRaH5NTZDYhLhSKMUdtY+i8sKkjjFwiDYhy6688G+H8oFklIwPNeApKH8Jw5bbtuH6onIzo1oivapOFJryg=="
+      "version": "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c.tgz",
+      "integrity": "sha512-o9oSp2c5yDWHn9TT2Ntv3cb6LuJKPBy32gTtipYH1D166KfKBy+1RkPySobWZCKV/TrkUGlcBn5vcQgRBHPvVA=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -3292,9 +3299,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
+      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -4237,9 +4244,9 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }
@@ -4477,12 +4484,20 @@
       "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
     },
     "prisma": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.6.1.tgz",
-      "integrity": "sha512-BR4itMCuzrDV4tn3e2TF+nh1zIX/RVU0isKtKoN28ADeoJ9nYaMhiuRRkFd2TZN8+l/XfYzoRKyHzUFXLQhmBQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.7.0.tgz",
+      "integrity": "sha512-VsecNo0Ca3+bDTzSpJqIpdupKVhhQ8aOYeWc09JlUM89knqvhSrlMrg0U8BiOD4tFrY1OPaCcraK8leDBxKMBg==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.6.1"
+        "@prisma/engines": "4.7.0"
+      },
+      "dependencies": {
+        "@prisma/engines": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.7.0.tgz",
+          "integrity": "sha512-afKrVFktaZ1pOK12/uFl2hRsBWIJZuC5FdDtacuKk5x/mR+rC5AbA+PlN3ZCZbmYTaeiBMHjcU5wbT5z2N3nSQ==",
+          "devOptional": true
+        }
       }
     },
     "process-nextick-args": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-zod-generator",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "gen-example": "tsc && npx prisma generate",
-    "package:publish": "./package.sh && cd package && npm publish"
+    "package:publish": "./package.sh && cd package && npm publish",
+    "postinstall": "tsc"
   },
   "author": {
     "name": "Omar Dulaimi",

--- a/package.json
+++ b/package.json
@@ -24,19 +24,19 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^4.0.0",
-    "@prisma/generator-helper": "^4.0.0",
-    "@prisma/internals": "^4.0.0",
+    "@prisma/client": "^4.3.1",
+    "@prisma/generator-helper": "^4.3.1",
+    "@prisma/internals": "^4.3.1",
     "prettier": "^2.7.1",
     "tslib": "^2.4.0",
-    "zod": "^3.17.3"
+    "zod": "^3.18.0"
   },
   "devDependencies": {
-    "@types/node": "^18.0.3",
-    "@types/prettier": "^2.6.3",
-    "prisma": "^4.0.0",
-    "typescript": "^4.7.4",
-    "ts-node": "^10.8.2"
+    "@types/node": "^18.7.15",
+    "@types/prettier": "^2.7.0",
+    "prisma": "^4.3.1",
+    "typescript": "^4.8.2",
+    "ts-node": "^10.9.1"
   },
   "bugs": {
     "url": "https://github.com/omar-dulaimi/prisma-zod-generator/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "gen-example": "tsc && npx prisma generate",
-    "package:publish": "./package.sh && cd package && npm publish",
-    "postinstall": "tsc"
+    "package:publish": "./package.sh && cd package && npm publish"
   },
   "author": {
     "name": "Omar Dulaimi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "gen-example": "tsc && npx prisma generate",
-    "package:publish": "./package.sh && cd package && npm publish"
+    "package:publish": "npm update && ./package.sh && cd package && npm publish"
   },
   "author": {
     "name": "Omar Dulaimi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "gen-example": "tsc && npx prisma generate",
-    "package:publish": "npm update && ./package.sh && cd package && npm publish"
+    "check-uncommitted": "git diff-index --quiet HEAD --",
+    "package:publish": "npm update && npm run check-uncommitted && ./package.sh && cd package && npm publish"
   },
   "author": {
     "name": "Omar Dulaimi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -25,19 +25,19 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^4.3.1",
-    "@prisma/generator-helper": "^4.3.1",
-    "@prisma/internals": "^4.3.1",
-    "prettier": "^2.7.1",
-    "tslib": "^2.4.0",
-    "zod": "^3.18.0"
+    "@prisma/client": "^4.8.0",
+    "@prisma/generator-helper": "^4.8.0",
+    "@prisma/internals": "^4.8.0",
+    "prettier": "^2.8.1",
+    "tslib": "^2.4.1",
+    "zod": "^3.20.2"
   },
   "devDependencies": {
-    "@types/node": "^18.7.15",
-    "@types/prettier": "^2.7.0",
-    "prisma": "^4.3.1",
+    "@types/node": "^18.11.18",
+    "@types/prettier": "^2.7.2",
+    "prisma": "^4.8.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.2"
+    "typescript": "^4.9.4"
   },
   "bugs": {
     "url": "https://github.com/omar-dulaimi/prisma-zod-generator/issues"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@types/node": "^18.7.15",
     "@types/prettier": "^2.7.0",
     "prisma": "^4.3.1",
-    "typescript": "^4.8.2",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.8.2"
   },
   "bugs": {
     "url": "https://github.com/omar-dulaimi/prisma-zod-generator/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,4 +29,5 @@ model Post {
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
+  likes     BigInt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Post {
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
   likes     BigInt
+  bytes     Bytes
 }
 
 /// @@Gen.model(hide: true)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,3 +33,8 @@ model Post {
   authorId  Int?
   likes     BigInt
 }
+
+model Book {
+  id Int @unique
+  title String
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,9 +8,10 @@ datasource db {
 }
 
 generator zod {
-  provider = "node ./lib/generator.js"
-  output   = "./generated"  
-  isGenerateSelect = true
+  provider          = "node ./lib/generator.js"
+  output            = "./generated"
+  isGenerateSelect  = true
+  isGenerateInclude = true
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,8 @@ datasource db {
 
 generator zod {
   provider = "node ./lib/generator.js"
-  output   = "./generated"
+  output   = "./generated"  
+  isGenerateSelect = true
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   email String  @unique
   name  String?
   posts Post[]
+  books Book[]
 }
 
 model Post {
@@ -34,12 +35,15 @@ model Post {
   likes     BigInt
 }
 
+/// @@Gen.model(hide: true)
+model Book {
+  id       Int    @unique
+  title    String
+  author   User?  @relation(fields: [authorId], references: [id])
+  authorId Int?
+}
+
 model Map {
   key   String @id
   value String
-}
-
-model Book {
-  id Int @unique
-  title String
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,11 @@ model Post {
   likes     BigInt
 }
 
+model Map {
+  key   String @id
+  value String
+}
+
 model Book {
   id Int @unique
   title String

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,2 @@
+export const isMongodbRawOp = (name: string) =>
+  /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,0 @@
-export const isMongodbRawOp = (name: string) =>
-  /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);
-
-export const isAggregateOutputType = (name: string) =>
-  /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,2 +1,5 @@
 export const isMongodbRawOp = (name: string) =>
   /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);
+
+export const isAggregateOutputType = (name: string) =>
+  /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);

--- a/src/helpers/aggregate-helpers.ts
+++ b/src/helpers/aggregate-helpers.ts
@@ -1,0 +1,32 @@
+import { DMMF } from '@prisma/generator-helper';
+
+const isAggregateOutputType = (name: string) =>
+  /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);
+
+export function addMissingInputObjectTypesForAggregate(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+) {
+  const aggregateOutputTypes = outputObjectTypes.filter(({ name }) =>
+    isAggregateOutputType(name),
+  );
+  for (const aggregateOutputType of aggregateOutputTypes) {
+    const name = aggregateOutputType.name.replace(/(?:OutputType|Output)$/, '');
+    inputObjectTypes.push({
+      constraints: { maxNumFields: null, minNumFields: null },
+      name: `${name}Input`,
+      fields: aggregateOutputType.fields.map((field) => ({
+        name: field.name,
+        isNullable: false,
+        isRequired: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: 'True',
+            location: 'scalar',
+          },
+        ],
+      })),
+    });
+  }
+}

--- a/src/helpers/aggregate-helpers.ts
+++ b/src/helpers/aggregate-helpers.ts
@@ -1,7 +1,15 @@
 import { DMMF } from '@prisma/generator-helper';
+import { AggregateOperationSupport } from '../types';
 
 const isAggregateOutputType = (name: string) =>
   /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);
+
+export const isAggregateInputType = (name: string) =>
+  name.endsWith('CountAggregateInput') ||
+  name.endsWith('SumAggregateInput') ||
+  name.endsWith('AvgAggregateInput') ||
+  name.endsWith('MinAggregateInput') ||
+  name.endsWith('MaxAggregateInput');
 
 export function addMissingInputObjectTypesForAggregate(
   inputObjectTypes: DMMF.InputType[],
@@ -29,4 +37,47 @@ export function addMissingInputObjectTypesForAggregate(
       })),
     });
   }
+}
+
+export function resolveAggregateOperationSupport(
+  inputObjectTypes: DMMF.InputType[],
+) {
+  const aggregateOperationSupport: AggregateOperationSupport = {};
+  for (const inputType of inputObjectTypes) {
+    if (isAggregateInputType(inputType.name)) {
+      const name = inputType.name.replace('AggregateInput', '');
+      if (name.endsWith('Count')) {
+        const model = name.replace('Count', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          count: true,
+        };
+      } else if (name.endsWith('Min')) {
+        const model = name.replace('Min', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          min: true,
+        };
+      } else if (name.endsWith('Max')) {
+        const model = name.replace('Max', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          max: true,
+        };
+      } else if (name.endsWith('Sum')) {
+        const model = name.replace('Sum', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          sum: true,
+        };
+      } else if (name.endsWith('Avg')) {
+        const model = name.replace('Avg', '');
+        aggregateOperationSupport[model] = {
+          ...aggregateOperationSupport[model],
+          avg: true,
+        };
+      }
+    }
+  }
+  return aggregateOperationSupport;
 }

--- a/src/helpers/comments-helpers.ts
+++ b/src/helpers/comments-helpers.ts
@@ -1,0 +1,128 @@
+import { DMMF } from '@prisma/generator-helper';
+
+const modelAttributeRegex = /(@@Gen\.)+([A-z])+(\()+(.+)+(\))+/;
+const attributeNameRegex = /(?:\.)+([A-Za-z])+(?:\()+/;
+const attributeArgsRegex = /(?:\()+([A-Za-z])+\:+(.+)+(?:\))+/;
+
+export function resolveModelsComments(
+  models: DMMF.Model[],
+  modelOperations: DMMF.ModelMapping[],
+  enumTypes: { model?: DMMF.SchemaEnum[]; prisma: DMMF.SchemaEnum[] },
+  hiddenModels: string[],
+  hiddenFields: string[],
+) {
+  models = collectHiddenModels(models, hiddenModels);
+  collectHiddenFields(models, hiddenModels, hiddenFields);
+  hideModelOperations(models, modelOperations);
+  hideEnums(enumTypes, hiddenModels);
+}
+
+function collectHiddenModels(models: DMMF.Model[], hiddenModels: string[]) {
+  return models
+    .map((model) => {
+      if (model.documentation) {
+        const attribute = model.documentation?.match(modelAttributeRegex)?.[0];
+        const attributeName = attribute
+          ?.match(attributeNameRegex)?.[0]
+          ?.slice(1, -1);
+        if (attributeName !== 'model') model;
+        const rawAttributeArgs = attribute
+          ?.match(attributeArgsRegex)?.[0]
+          ?.slice(1, -1);
+
+        const parsedAttributeArgs: Record<string, unknown> = {};
+        if (rawAttributeArgs) {
+          const rawAttributeArgsParts = rawAttributeArgs
+            .split(':')
+            .map((it) => it.trim())
+            .map((part) => (part.startsWith('[') ? part : part.split(',')))
+            .flat()
+            .map((it) => it.trim());
+
+          for (let i = 0; i < rawAttributeArgsParts.length; i += 2) {
+            const key = rawAttributeArgsParts[i];
+            const value = rawAttributeArgsParts[i + 1];
+            parsedAttributeArgs[key] = JSON.parse(value);
+          }
+        }
+        if (parsedAttributeArgs.hide) {
+          hiddenModels.push(model.name);
+          return null as unknown as DMMF.Model;
+        }
+      }
+      return model;
+    })
+    .filter(Boolean);
+}
+
+function collectHiddenFields(
+  models: DMMF.Model[],
+  hiddenModels: string[],
+  hiddenFields: string[],
+) {
+  models.forEach((model) => {
+    model.fields.forEach((field) => {
+      if (hiddenModels.includes(field.type)) {
+        hiddenFields.push(field.name);
+        if (field.relationFromFields) {
+          field.relationFromFields.forEach((item) => hiddenFields.push(item));
+        }
+      }
+    });
+  });
+}
+function hideEnums(
+  enumTypes: { model?: DMMF.SchemaEnum[]; prisma: DMMF.SchemaEnum[] },
+  hiddenModels: string[],
+) {
+  enumTypes.prisma = enumTypes.prisma.filter(
+    (item) => !hiddenModels.find((model) => item.name.startsWith(model)),
+  );
+}
+
+function hideModelOperations(
+  models: DMMF.Model[],
+  modelOperations: DMMF.ModelMapping[],
+) {
+  let i = modelOperations.length;
+  while (i >= 0) {
+    --i;
+    const modelOperation = modelOperations[i];
+    if (
+      modelOperation &&
+      !models.find((model) => {
+        return model.name === modelOperation.model;
+      })
+    ) {
+      modelOperations.splice(i, 1);
+    }
+  }
+}
+
+export function hideInputObjectTypesAndRelatedFields(
+  inputObjectTypes: DMMF.InputType[],
+  hiddenModels: string[],
+  hiddenFields: string[],
+) {
+  let j = inputObjectTypes.length;
+  while (j >= 0) {
+    --j;
+    const inputType = inputObjectTypes[j];
+    if (
+      inputType &&
+      (hiddenModels.includes(inputType?.meta?.source as string) ||
+        hiddenModels.find((model) => inputType.name.startsWith(model)))
+    ) {
+      inputObjectTypes.splice(j, 1);
+    } else {
+      let k = inputType?.fields?.length ?? 0;
+      while (k >= 0) {
+        --k;
+        const field = inputType?.fields?.[k];
+        if (field && hiddenFields.includes(field.name)) {
+          inputObjectTypes[j].fields.splice(k, 1);
+        }
+      }
+    }
+  }
+}

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -3,9 +3,12 @@ import Transformer from '../transformer';
 import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
 import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
 import { addMissingInputObjectTypesForSelect } from './select-helpers';
+import { addMissingInputObjectTypesForInclude } from './include-helpers';
+import { addMissingInputObjectTypesForModelArgs } from './modelArgs-helpers';
 
 interface AddMissingInputObjectTypeOptions {
   isGenerateSelect: boolean;
+  isGenerateInclude: boolean;
 }
 
 export function addMissingInputObjectTypes(
@@ -33,6 +36,22 @@ export function addMissingInputObjectTypes(
     );
     Transformer.setIsGenerateSelect(true);
   }
+  if (options.isGenerateSelect || options.isGenerateInclude) {
+    addMissingInputObjectTypesForModelArgs(
+      inputObjectTypes,
+      models,
+      options.isGenerateSelect,
+      options.isGenerateInclude,
+    );
+  }
+  if (options.isGenerateInclude) {
+    addMissingInputObjectTypesForInclude(
+      inputObjectTypes,
+      models,
+      options.isGenerateSelect,
+    );
+    Transformer.setIsGenerateInclude(true);
+  }
 }
 
 export function resolveAddMissingInputObjectTypeOptions(
@@ -40,5 +59,6 @@ export function resolveAddMissingInputObjectTypeOptions(
 ): AddMissingInputObjectTypeOptions {
   return {
     isGenerateSelect: generatorConfigOptions.isGenerateSelect === 'true',
+    isGenerateInclude: generatorConfigOptions.isGenerateInclude === 'true',
   };
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,10 +1,11 @@
-import { DMMF, ConnectorType, Dictionary } from '@prisma/generator-helper';
+import { ConnectorType, Dictionary, DMMF } from '@prisma/generator-helper';
 import Transformer from '../transformer';
-import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
 import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
-import { addMissingInputObjectTypesForSelect } from './select-helpers';
 import { addMissingInputObjectTypesForInclude } from './include-helpers';
 import { addMissingInputObjectTypesForModelArgs } from './modelArgs-helpers';
+import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
+import { addMissingInputObjectTypesForSelect } from './select-helpers';
+import { changeOptionalToRequiredFields } from './whereUniqueInput-helpers';
 
 interface AddMissingInputObjectTypeOptions {
   isGenerateSelect: boolean;
@@ -52,6 +53,8 @@ export function addMissingInputObjectTypes(
     );
     Transformer.setIsGenerateInclude(true);
   }
+
+  changeOptionalToRequiredFields(inputObjectTypes);
 }
 
 export function resolveAddMissingInputObjectTypeOptions(

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,0 +1,44 @@
+import { DMMF, ConnectorType, Dictionary } from '@prisma/generator-helper';
+import Transformer from '../transformer';
+import { addMissingInputObjectTypesForMongoDbRawOpsAndQueries } from './mongodb-helpers';
+import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
+import { addMissingInputObjectTypesForSelect } from './select-helpers';
+
+interface AddMissingInputObjectTypeOptions {
+  isGenerateSelect: boolean;
+}
+
+export function addMissingInputObjectTypes(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+  models: DMMF.Model[],
+  modelOperations: DMMF.ModelMapping[],
+  dataSourceProvider: ConnectorType,
+  options: AddMissingInputObjectTypeOptions,
+) {
+  // TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
+  if (dataSourceProvider === 'mongodb') {
+    addMissingInputObjectTypesForMongoDbRawOpsAndQueries(
+      modelOperations,
+      outputObjectTypes,
+      inputObjectTypes,
+    );
+  }
+  addMissingInputObjectTypesForAggregate(inputObjectTypes, outputObjectTypes);
+  if (options.isGenerateSelect) {
+    addMissingInputObjectTypesForSelect(
+      inputObjectTypes,
+      outputObjectTypes,
+      models,
+    );
+    Transformer.setIsGenerateSelect(true);
+  }
+}
+
+export function resolveAddMissingInputObjectTypeOptions(
+  generatorConfigOptions: Dictionary<string>,
+): AddMissingInputObjectTypeOptions {
+  return {
+    isGenerateSelect: generatorConfigOptions.isGenerateSelect === 'true',
+  };
+}

--- a/src/helpers/include-helpers.ts
+++ b/src/helpers/include-helpers.ts
@@ -1,4 +1,9 @@
 import { DMMF } from '@prisma/generator-helper';
+import {
+  checkIsModelRelationField,
+  checkModelHasModelRelation,
+  checkModelHasManyModelRelation,
+} from './model-helpers';
 
 export function addMissingInputObjectTypesForInclude(
   inputObjectTypes: DMMF.InputType[],
@@ -6,14 +11,10 @@ export function addMissingInputObjectTypesForInclude(
   isGenerateSelect: boolean,
 ) {
   // generate input object types necessary to support ModelInclude with relation support
-  const modelIncludeInputObjectTypes = generateModelIncludeInputObjectTypes(
+  const generatedIncludeInputObjectTypes = generateModelIncludeInputObjectTypes(
     models,
     isGenerateSelect,
   );
-
-  const generatedIncludeInputObjectTypes = [
-    modelIncludeInputObjectTypes,
-  ].flat();
 
   for (const includeInputObjectType of generatedIncludeInputObjectTypes) {
     inputObjectTypes.push(includeInputObjectType);
@@ -28,21 +29,10 @@ function generateModelIncludeInputObjectTypes(
     const { name: modelName, fields: modelFields } = model;
     const fields: DMMF.SchemaArg[] = [];
 
-    let hasManyRelation = false;
-
     for (const modelField of modelFields) {
-      const {
-        name: modelFieldName,
-        kind,
-        relationName,
-        isList,
-        type,
-      } = modelField;
+      const { name: modelFieldName, isList, type } = modelField;
 
-      const isRelationField = kind === 'object' && !!relationName;
-      if (isRelationField && isList) {
-        hasManyRelation = true;
-      }
+      const isRelationField = checkIsModelRelationField(modelField);
 
       if (isRelationField) {
         const field: DMMF.SchemaArg = {
@@ -63,7 +53,18 @@ function generateModelIncludeInputObjectTypes(
       }
     }
 
-    const shouldAddCountField = hasManyRelation;
+    /**
+     * include is not generated for models that do not have a relation with any other models
+     * -> continue onto the next model
+     */
+    const hasRelationToAnotherModel = checkModelHasModelRelation(model);
+    if (!hasRelationToAnotherModel) {
+      continue;
+    }
+
+    const hasManyRelationToAnotherModel = checkModelHasManyModelRelation(model);
+
+    const shouldAddCountField = hasManyRelationToAnotherModel;
     if (shouldAddCountField) {
       const inputTypes: DMMF.SchemaArgInputType[] = [
         { isList: false, type: 'Boolean', location: 'scalar' },

--- a/src/helpers/include-helpers.ts
+++ b/src/helpers/include-helpers.ts
@@ -1,0 +1,99 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypesForInclude(
+  inputObjectTypes: DMMF.InputType[],
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+) {
+  // generate input object types necessary to support ModelInclude with relation support
+  const modelIncludeInputObjectTypes = generateModelIncludeInputObjectTypes(
+    models,
+    isGenerateSelect,
+  );
+
+  const generatedIncludeInputObjectTypes = [
+    modelIncludeInputObjectTypes,
+  ].flat();
+
+  for (const includeInputObjectType of generatedIncludeInputObjectTypes) {
+    inputObjectTypes.push(includeInputObjectType);
+  }
+}
+function generateModelIncludeInputObjectTypes(
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+) {
+  const modelIncludeInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName, fields: modelFields } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    let hasManyRelation = false;
+
+    for (const modelField of modelFields) {
+      const {
+        name: modelFieldName,
+        kind,
+        relationName,
+        isList,
+        type,
+      } = modelField;
+
+      const isRelationField = kind === 'object' && !!relationName;
+      if (isRelationField && isList) {
+        hasManyRelation = true;
+      }
+
+      if (isRelationField) {
+        const field: DMMF.SchemaArg = {
+          name: modelFieldName,
+          isRequired: false,
+          isNullable: false,
+          inputTypes: [
+            { isList: false, type: 'Boolean', location: 'scalar' },
+            {
+              isList: false,
+              type: isList ? `${type}FindManyArgs` : `${type}Args`,
+              location: 'inputObjectTypes',
+              namespace: 'prisma',
+            },
+          ],
+        };
+        fields.push(field);
+      }
+    }
+
+    const shouldAddCountField = hasManyRelation;
+    if (shouldAddCountField) {
+      const inputTypes: DMMF.SchemaArgInputType[] = [
+        { isList: false, type: 'Boolean', location: 'scalar' },
+      ];
+      if (isGenerateSelect) {
+        inputTypes.push({
+          isList: false,
+          type: `${modelName}CountOutputTypeArgs`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        });
+      }
+      const _countField: DMMF.SchemaArg = {
+        name: '_count',
+        isRequired: false,
+        isNullable: false,
+        inputTypes,
+      };
+      fields.push(_countField);
+    }
+
+    const modelIncludeInputObjectType: DMMF.InputType = {
+      name: `${modelName}Include`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelIncludeInputObjectTypes.push(modelIncludeInputObjectType);
+  }
+  return modelIncludeInputObjectTypes;
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './helpers';
+export * from './mongodb-helpers';

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,4 +2,5 @@ export * from './comments-helpers';
 export * from './helpers';
 export * from './model-helpers';
 export * from './mongodb-helpers';
+export * from "./whereUniqueInput-helpers";
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './helpers';
+export * from './model-helpers';
 export * from './mongodb-helpers';

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,5 @@
+export * from './comments-helpers';
 export * from './helpers';
 export * from './model-helpers';
 export * from './mongodb-helpers';
+

--- a/src/helpers/model-helpers.ts
+++ b/src/helpers/model-helpers.ts
@@ -1,0 +1,36 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function checkModelHasModelRelation(model: DMMF.Model) {
+  const { fields: modelFields } = model;
+  for (const modelField of modelFields) {
+    const isRelationField = checkIsModelRelationField(modelField);
+    if (isRelationField) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function checkModelHasManyModelRelation(model: DMMF.Model) {
+  const { fields: modelFields } = model;
+  for (const modelField of modelFields) {
+    const isManyRelationField = checkIsManyModelRelationField(modelField);
+    if (isManyRelationField) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function checkIsModelRelationField(modelField: DMMF.Field) {
+  const { kind, relationName } = modelField;
+  return kind === 'object' && !!relationName;
+}
+
+export function checkIsManyModelRelationField(modelField: DMMF.Field) {
+  return checkIsModelRelationField(modelField) && modelField.isList;
+}
+
+export function findModelByName(models: DMMF.Model[], modelName: string) {
+  return models.find(({ name }) => name === modelName);
+}

--- a/src/helpers/modelArgs-helpers.ts
+++ b/src/helpers/modelArgs-helpers.ts
@@ -1,4 +1,5 @@
 import { DMMF } from '@prisma/generator-helper';
+import { checkModelHasModelRelation } from './model-helpers';
 
 export function addMissingInputObjectTypesForModelArgs(
   inputObjectTypes: DMMF.InputType[],
@@ -43,7 +44,9 @@ function generateModelArgsInputObjectTypes(
       fields.push(selectField);
     }
 
-    if (isGenerateInclude) {
+    const hasRelationToAnotherModel = checkModelHasModelRelation(model);
+
+    if (isGenerateInclude && hasRelationToAnotherModel) {
       const includeField: DMMF.SchemaArg = {
         name: 'include',
         isRequired: false,

--- a/src/helpers/modelArgs-helpers.ts
+++ b/src/helpers/modelArgs-helpers.ts
@@ -1,0 +1,74 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypesForModelArgs(
+  inputObjectTypes: DMMF.InputType[],
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+  isGenerateInclude: boolean,
+) {
+  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(
+    models,
+    isGenerateSelect,
+    isGenerateInclude,
+  );
+
+  for (const modelArgsInputObjectType of modelArgsInputObjectTypes) {
+    inputObjectTypes.push(modelArgsInputObjectType);
+  }
+}
+function generateModelArgsInputObjectTypes(
+  models: DMMF.Model[],
+  isGenerateSelect: boolean,
+  isGenerateInclude: boolean,
+) {
+  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    if (isGenerateSelect) {
+      const selectField: DMMF.SchemaArg = {
+        name: 'select',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `${modelName}Select`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(selectField);
+    }
+
+    if (isGenerateInclude) {
+      const includeField: DMMF.SchemaArg = {
+        name: 'include',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `${modelName}Include`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(includeField);
+    }
+
+    const modelArgsInputObjectType: DMMF.InputType = {
+      name: `${modelName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
+  }
+  return modelArgsInputObjectTypes;
+}

--- a/src/helpers/mongodb-helpers.ts
+++ b/src/helpers/mongodb-helpers.ts
@@ -1,0 +1,84 @@
+import { DMMF } from '@prisma/generator-helper';
+import Transformer from '../transformer';
+
+export function addMissingInputObjectTypesForMongoDbRawOpsAndQueries(
+  modelOperations: DMMF.ModelMapping[],
+  outputObjectTypes: DMMF.OutputType[],
+  inputObjectTypes: DMMF.InputType[],
+) {
+  const rawOpsMap = resolveMongoDbRawOperations(modelOperations);
+  Transformer.rawOpsMap = rawOpsMap ?? {};
+
+  const mongoDbRawQueryInputObjectTypes =
+    resolveMongoDbRawQueryInputObjectTypes(outputObjectTypes);
+  for (const mongoDbRawQueryInputType of mongoDbRawQueryInputObjectTypes) {
+    inputObjectTypes.push(mongoDbRawQueryInputType);
+  }
+}
+
+function resolveMongoDbRawOperations(modelOperations: DMMF.ModelMapping[]) {
+  const rawOpsMap: { [name: string]: string } = {};
+  const rawOpsNames = [
+    ...new Set(
+      modelOperations.reduce<string[]>((result, current) => {
+        const keys = Object.keys(current);
+        keys?.forEach((key) => {
+          if (key.includes('Raw')) {
+            result.push(key);
+          }
+        });
+        return result;
+      }, []),
+    ),
+  ];
+
+  const modelNames = modelOperations.map((item) => item.model);
+
+  rawOpsNames.forEach((opName) => {
+    modelNames.forEach((modelName) => {
+      const isFind = opName === 'findRaw';
+      const opWithModel = `${opName.replace('Raw', '')}${modelName}Raw`;
+      rawOpsMap[opWithModel] = isFind
+        ? `${modelName}FindRawArgs`
+        : `${modelName}AggregateRawArgs`;
+    });
+  });
+
+  return rawOpsMap;
+}
+
+function resolveMongoDbRawQueryInputObjectTypes(
+  outputObjectTypes: DMMF.OutputType[],
+) {
+  const mongoDbRawQueries = getMongoDbRawQueries(outputObjectTypes);
+  const mongoDbRawQueryInputObjectTypes = mongoDbRawQueries.map((item) => ({
+    name: item.name,
+    constraints: {
+      maxNumFields: null,
+      minNumFields: null,
+    },
+    fields: item.args.map((arg) => ({
+      name: arg.name,
+      isRequired: arg.isRequired,
+      isNullable: arg.isNullable,
+      inputTypes: arg.inputTypes,
+    })),
+  }));
+  return mongoDbRawQueryInputObjectTypes;
+}
+
+function getMongoDbRawQueries(outputObjectTypes: DMMF.OutputType[]) {
+  const queryOutputTypes = outputObjectTypes.filter(
+    (item) => item.name === 'Query',
+  );
+
+  const mongodbRawQueries =
+    queryOutputTypes?.[0].fields.filter((field) =>
+      field.name.includes('Raw'),
+    ) ?? [];
+
+  return mongodbRawQueries;
+}
+
+export const isMongodbRawOp = (name: string) =>
+  /find([^]*?)Raw/.test(name) || /aggregate([^]*?)Raw/.test(name);

--- a/src/helpers/select-helpers.ts
+++ b/src/helpers/select-helpers.ts
@@ -1,7 +1,7 @@
 import { DMMF } from '@prisma/generator-helper';
 import {
   checkIsModelRelationField,
-  checkModelHasManyModelRelation,
+  checkModelHasManyModelRelation
 } from './model-helpers';
 
 export function addMissingInputObjectTypesForSelect(

--- a/src/helpers/select-helpers.ts
+++ b/src/helpers/select-helpers.ts
@@ -1,0 +1,216 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function addMissingInputObjectTypesForSelect(
+  inputObjectTypes: DMMF.InputType[],
+  outputObjectTypes: DMMF.OutputType[],
+  models: DMMF.Model[],
+) {
+  // generate input object types necessary to support ModelSelect._count
+  const modelCountOutputTypes = getModelCountOutputTypes(outputObjectTypes);
+  const modelCountOutputTypeSelectInputObjectTypes =
+    generateModelCountOutputTypeSelectInputObjectTypes(modelCountOutputTypes);
+  const modelCountOutputTypeArgsInputObjectTypes =
+    generateModelCountOutputTypeArgsInputObjectTypes(modelCountOutputTypes);
+
+  // generate input object types necessary to support ModelSelect with relation support
+  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(models);
+  const modelSelectInputObjectTypes =
+    generateModelSelectInputObjectTypes(models);
+
+  const generatedInputObjectTypes = [
+    modelCountOutputTypeSelectInputObjectTypes,
+    modelCountOutputTypeArgsInputObjectTypes,
+    modelArgsInputObjectTypes,
+    modelSelectInputObjectTypes,
+  ].flat();
+
+  for (const inputObjectType of generatedInputObjectTypes) {
+    inputObjectTypes.push(inputObjectType);
+  }
+}
+
+function getModelCountOutputTypes(outputObjectTypes: DMMF.OutputType[]) {
+  return outputObjectTypes.filter(({ name }) =>
+    name.includes('CountOutputType'),
+  );
+}
+
+function generateModelCountOutputTypeSelectInputObjectTypes(
+  modelCountOutputTypes: DMMF.OutputType[],
+) {
+  const modelCountOutputTypeSelectInputObjectTypes: DMMF.InputType[] = [];
+  for (const modelCountOutputType of modelCountOutputTypes) {
+    const {
+      name: modelCountOutputTypeName,
+      fields: modelCountOutputTypeFields,
+    } = modelCountOutputType;
+    const modelCountOutputTypeSelectInputObjectType: DMMF.InputType = {
+      name: `${modelCountOutputTypeName}Select`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields: modelCountOutputTypeFields.map(({ name }) => ({
+        name,
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          {
+            isList: false,
+            type: `Boolean`,
+            location: 'scalar',
+          },
+        ],
+      })),
+    };
+    modelCountOutputTypeSelectInputObjectTypes.push(
+      modelCountOutputTypeSelectInputObjectType,
+    );
+  }
+  return modelCountOutputTypeSelectInputObjectTypes;
+}
+
+function generateModelCountOutputTypeArgsInputObjectTypes(
+  modelCountOutputTypes: DMMF.OutputType[],
+) {
+  const modelCountOutputTypeArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const modelCountOutputType of modelCountOutputTypes) {
+    const { name: modelCountOutputTypeName } = modelCountOutputType;
+    const modelCountOutputTypeArgsInputObjectType: DMMF.InputType = {
+      name: `${modelCountOutputTypeName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields: [
+        {
+          name: 'select',
+          isRequired: false,
+          isNullable: false,
+          inputTypes: [
+            {
+              isList: false,
+              type: `${modelCountOutputTypeName}Select`,
+              location: 'inputObjectTypes',
+              namespace: 'prisma',
+            },
+          ],
+        },
+      ],
+    };
+    modelCountOutputTypeArgsInputObjectTypes.push(
+      modelCountOutputTypeArgsInputObjectType,
+    );
+  }
+  return modelCountOutputTypeArgsInputObjectTypes;
+}
+
+function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
+  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    const selectField: DMMF.SchemaArg = {
+      name: 'select',
+      isRequired: false,
+      isNullable: false,
+      inputTypes: [
+        {
+          isList: false,
+          type: `${modelName}Select`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        },
+      ],
+    };
+    fields.push(selectField);
+
+    /** @todo add include field in a future pull request */
+
+    const modelArgsInputObjectType: DMMF.InputType = {
+      name: `${modelName}Args`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
+  }
+  return modelArgsInputObjectTypes;
+}
+
+function generateModelSelectInputObjectTypes(models: DMMF.Model[]) {
+  const modelSelectInputObjectTypes: DMMF.InputType[] = [];
+  for (const model of models) {
+    const { name: modelName, fields: modelFields } = model;
+    const fields: DMMF.SchemaArg[] = [];
+
+    let hasManyRelation = false;
+
+    for (const modelField of modelFields) {
+      const {
+        name: modelFieldName,
+        kind,
+        relationName,
+        isList,
+        type,
+      } = modelField;
+
+      const isRelationField = kind === 'object' && !!relationName;
+      if (isRelationField && isList) {
+        hasManyRelation = true;
+      }
+
+      const field: DMMF.SchemaArg = {
+        name: modelFieldName,
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [{ isList: false, type: 'Boolean', location: 'scalar' }],
+      };
+
+      if (isRelationField) {
+        let schemaArgInputType: DMMF.SchemaArgInputType = {
+          isList: false,
+          type: isList ? `${type}FindManyArgs` : `${type}Args`,
+          location: 'inputObjectTypes',
+          namespace: 'prisma',
+        };
+        field.inputTypes.push(schemaArgInputType);
+      }
+
+      fields.push(field);
+    }
+
+    const shouldAddCountField = hasManyRelation;
+    if (shouldAddCountField) {
+      const _countField: DMMF.SchemaArg = {
+        name: '_count',
+        isRequired: false,
+        isNullable: false,
+        inputTypes: [
+          { isList: false, type: 'Boolean', location: 'scalar' },
+          {
+            isList: false,
+            type: `${modelName}CountOutputTypeArgs`,
+            location: 'inputObjectTypes',
+            namespace: 'prisma',
+          },
+        ],
+      };
+      fields.push(_countField);
+    }
+
+    const modelSelectInputObjectType: DMMF.InputType = {
+      name: `${modelName}Select`,
+      constraints: {
+        maxNumFields: null,
+        minNumFields: null,
+      },
+      fields,
+    };
+    modelSelectInputObjectTypes.push(modelSelectInputObjectType);
+  }
+  return modelSelectInputObjectTypes;
+}

--- a/src/helpers/select-helpers.ts
+++ b/src/helpers/select-helpers.ts
@@ -12,15 +12,12 @@ export function addMissingInputObjectTypesForSelect(
   const modelCountOutputTypeArgsInputObjectTypes =
     generateModelCountOutputTypeArgsInputObjectTypes(modelCountOutputTypes);
 
-  // generate input object types necessary to support ModelSelect with relation support
-  const modelArgsInputObjectTypes = generateModelArgsInputObjectTypes(models);
   const modelSelectInputObjectTypes =
     generateModelSelectInputObjectTypes(models);
 
   const generatedInputObjectTypes = [
     modelCountOutputTypeSelectInputObjectTypes,
     modelCountOutputTypeArgsInputObjectTypes,
-    modelArgsInputObjectTypes,
     modelSelectInputObjectTypes,
   ].flat();
 
@@ -103,42 +100,6 @@ function generateModelCountOutputTypeArgsInputObjectTypes(
     );
   }
   return modelCountOutputTypeArgsInputObjectTypes;
-}
-
-function generateModelArgsInputObjectTypes(models: DMMF.Model[]) {
-  const modelArgsInputObjectTypes: DMMF.InputType[] = [];
-  for (const model of models) {
-    const { name: modelName } = model;
-    const fields: DMMF.SchemaArg[] = [];
-
-    const selectField: DMMF.SchemaArg = {
-      name: 'select',
-      isRequired: false,
-      isNullable: false,
-      inputTypes: [
-        {
-          isList: false,
-          type: `${modelName}Select`,
-          location: 'inputObjectTypes',
-          namespace: 'prisma',
-        },
-      ],
-    };
-    fields.push(selectField);
-
-    /** @todo add include field in a future pull request */
-
-    const modelArgsInputObjectType: DMMF.InputType = {
-      name: `${modelName}Args`,
-      constraints: {
-        maxNumFields: null,
-        minNumFields: null,
-      },
-      fields,
-    };
-    modelArgsInputObjectTypes.push(modelArgsInputObjectType);
-  }
-  return modelArgsInputObjectTypes;
 }
 
 function generateModelSelectInputObjectTypes(models: DMMF.Model[]) {

--- a/src/helpers/whereUniqueInput-helpers.ts
+++ b/src/helpers/whereUniqueInput-helpers.ts
@@ -1,0 +1,21 @@
+import { DMMF } from '@prisma/generator-helper';
+
+export function changeOptionalToRequiredFields(
+  inputObjectTypes: DMMF.InputType[],
+) {
+  inputObjectTypes.map((item) => {
+    if (
+      item.name.includes('WhereUniqueInput') &&
+      item.constraints.fields?.length! > 0
+    ) {
+      item.fields = item.fields.map((subItem) => {
+        if (item.constraints.fields?.includes(subItem.name)) {
+          subItem.isRequired = true;
+          return subItem;
+        }
+        return subItem;
+      });
+    }
+    return item;
+  });
+}

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -1,8 +1,8 @@
-import { parseEnvValue, getDMMF } from '@prisma/internals';
 import { EnvValue, GeneratorOptions } from '@prisma/generator-helper';
-import removeDir from './utils/removeDir';
+import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
 import Transformer from './transformer';
+import removeDir from './utils/removeDir';
 
 export async function generate(options: GeneratorOptions) {
   const outputDir = parseEnvValue(options.generator.output as EnvValue);
@@ -17,6 +17,8 @@ export async function generate(options: GeneratorOptions) {
     datamodel: options.datamodel,
     previewFeatures: prismaClientProvider?.previewFeatures,
   });
+
+  const dataSource = options.datasources?.[0];
 
   Transformer.isDefaultPrismaClientOutput =
     prismaClientProvider?.isCustomOutput ?? false;
@@ -39,13 +41,77 @@ export async function generate(options: GeneratorOptions) {
   });
   await enumsObj.printEnumSchemas();
 
-  for (
-    let i = 0;
-    i < prismaClientDmmf.schema.inputObjectTypes.prisma.length;
-    i += 1
-  ) {
-    const fields = prismaClientDmmf.schema.inputObjectTypes.prisma[i]?.fields;
-    const name = prismaClientDmmf.schema.inputObjectTypes.prisma[i]?.name;
+  const inputObjectTypes = prismaClientDmmf.schema.inputObjectTypes.prisma;
+  const rawOpsMap: { [name: string]: string } = {};
+
+  /* 
+  TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
+  */
+  if (dataSource.provider === 'mongodb') {
+    const modelNames = prismaClientDmmf.mappings.modelOperations.map(
+      (item) => item.model,
+    );
+    const rawOpsNames = [
+      ...new Set(
+        prismaClientDmmf.mappings.modelOperations.reduce<string[]>(
+          (result, current) => {
+            const keys = Object.keys(current);
+            keys?.forEach((key) => {
+              if (key.includes('Raw')) {
+                result.push(key);
+              }
+            });
+            return result;
+          },
+          [],
+        ),
+      ),
+    ];
+
+    rawOpsNames.forEach((opName) => {
+      modelNames.forEach((modelName) => {
+        const isFind = opName === 'findRaw';
+        const opWithModel = `${opName.replace('Raw', '')}${modelName}Raw`;
+        rawOpsMap[opWithModel] = isFind
+          ? `${modelName}FindRawArgs`
+          : `${modelName}AggregateRawArgs`;
+      });
+    });
+
+    Transformer.rawOpsMap = rawOpsMap ?? {};
+
+    const queryOutputTypes =
+      prismaClientDmmf.schema.outputObjectTypes.prisma.filter(
+        (item) => item.name === 'Query',
+      );
+
+    const mongodbRawQueries =
+      queryOutputTypes?.[0].fields.filter((field) =>
+        field.name.includes('Raw'),
+      ) ?? [];
+
+    mongodbRawQueries.forEach((item) => {
+      inputObjectTypes.push({
+        name: item.name,
+        constraints: {
+          maxNumFields: null,
+          minNumFields: null,
+        },
+        fields: item.args.map((arg) => ({
+          name: arg.name,
+          isRequired: arg.isRequired,
+          isNullable: arg.isNullable,
+          inputTypes: arg.inputTypes,
+        })),
+      });
+    });
+  }
+
+  Transformer.provider = dataSource.provider;
+
+  for (let i = 0; i < inputObjectTypes.length; i += 1) {
+    const fields = inputObjectTypes[i]?.fields;
+    const name = inputObjectTypes[i]?.name;
     const obj = new Transformer({ name, fields });
     await obj.printObjectSchemas();
   }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -18,6 +18,14 @@ export async function generate(options: GeneratorOptions) {
     previewFeatures: prismaClientProvider?.previewFeatures,
   });
 
+  Transformer.isDefaultPrismaClientOutput =
+    prismaClientProvider?.isCustomOutput ?? false;
+
+  if (prismaClientProvider?.isCustomOutput) {
+    Transformer.prismaClientOutputPath =
+      prismaClientProvider?.output?.value ?? '';
+  }
+
   Transformer.setOutputPath(outputDir);
 
   const enumTypes = [

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -86,6 +86,7 @@ export async function generate(options: GeneratorOptions) {
       modelOperations,
       aggregateOperationSupport,
     );
+    await generateIndex();
   } catch (error) {
     console.error(error);
   }
@@ -152,4 +153,8 @@ async function generateModelSchemas(
     aggregateOperationSupport,
   });
   await transformer.generateModelSchemas();
+}
+
+async function generateIndex() {
+  await Transformer.generateIndex();
 }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -54,7 +54,7 @@ export async function generate(options: GeneratorOptions) {
   );
   await generateObjectSchemas(inputObjectTypes);
 
-  await generateModelSchemas(modelOperations);
+  await generateModelSchemas(models, modelOperations);
 }
 
 async function handleGeneratorOutputValue(generatorOutputValue: EnvValue) {
@@ -107,8 +107,12 @@ async function generateObjectSchemas(inputObjectTypes: DMMF.InputType[]) {
   }
 }
 
-async function generateModelSchemas(modelOperations: DMMF.ModelMapping[]) {
+async function generateModelSchemas(
+  models: DMMF.Model[],
+  modelOperations: DMMF.ModelMapping[],
+) {
   const transformer = new Transformer({
+    models,
     modelOperations,
   });
   await transformer.generateModelSchemas();

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -1,148 +1,115 @@
-import { EnvValue, GeneratorOptions } from '@prisma/generator-helper';
+import {
+  DMMF,
+  EnvValue,
+  GeneratorConfig,
+  GeneratorOptions,
+} from '@prisma/generator-helper';
 import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
-import { isAggregateOutputType } from './helpers';
 import Transformer from './transformer';
 import removeDir from './utils/removeDir';
+import {
+  addMissingInputObjectTypes,
+  resolveAddMissingInputObjectTypeOptions,
+} from './helpers';
 
 export async function generate(options: GeneratorOptions) {
-  const outputDir = parseEnvValue(options.generator.output as EnvValue);
-  await fs.mkdir(outputDir, { recursive: true });
-  await removeDir(outputDir, true);
+  await handleGeneratorOutputValue(options.generator.output as EnvValue);
 
-  const prismaClientProvider = options.otherGenerators.find(
-    (it) => parseEnvValue(it.provider) === 'prisma-client-js',
+  const prismaClientGeneratorConfig = getGeneratorConfigByProvider(
+    options.otherGenerators,
+    'prisma-client-js',
   );
 
   const prismaClientDmmf = await getDMMF({
     datamodel: options.datamodel,
-    previewFeatures: prismaClientProvider?.previewFeatures,
+    previewFeatures: prismaClientGeneratorConfig?.previewFeatures,
   });
 
-  const dataSource = options.datasources?.[0];
+  checkForCustomPrismaClientOutputPath(prismaClientGeneratorConfig);
 
-  Transformer.isDefaultPrismaClientOutput =
-    prismaClientProvider?.isCustomOutput ?? false;
+  await generateEnumSchemas(
+    prismaClientDmmf.schema.enumTypes.prisma,
+    prismaClientDmmf.schema.enumTypes.model ?? [],
+  );
 
-  if (prismaClientProvider?.isCustomOutput) {
-    Transformer.prismaClientOutputPath =
-      prismaClientProvider?.output?.value ?? '';
-  }
-
-  Transformer.setOutputPath(outputDir);
-
-  const enumTypes = [
-    ...prismaClientDmmf.schema.enumTypes.prisma,
-    ...(prismaClientDmmf.schema.enumTypes.model ?? []),
-  ];
-  const enumNames = enumTypes.map((enumItem) => enumItem.name);
-  Transformer.enumNames = enumNames ?? [];
-  const enumsObj = new Transformer({
-    enumTypes,
-  });
-  await enumsObj.printEnumSchemas();
-
+  const models = prismaClientDmmf.datamodel.models;
+  const modelOperations = prismaClientDmmf.mappings.modelOperations;
   const inputObjectTypes = prismaClientDmmf.schema.inputObjectTypes.prisma;
   const outputObjectTypes = prismaClientDmmf.schema.outputObjectTypes.prisma;
 
-  outputObjectTypes.forEach((outputObjectType) => {
-    if (isAggregateOutputType(outputObjectType.name)) {
-      const name = outputObjectType.name.replace(/(?:OutputType|Output)$/, '');
-      inputObjectTypes.push({
-        constraints: { maxNumFields: null, minNumFields: null },
-        name: `${name}Input`,
-        fields: outputObjectType.fields.map((field) => ({
-          name: field.name,
-          isNullable: false,
-          isRequired: false,
-          inputTypes: [
-            {
-              isList: false,
-              type: 'True',
-              location: 'scalar',
-            },
-          ],
-        })),
-      });
-    }
-  });
-
-  const rawOpsMap: { [name: string]: string } = {};
-
-  /*
-  TODO: remove once Prisma fix this issue: https://github.com/prisma/prisma/issues/14900
-  */
-  if (dataSource.provider === 'mongodb') {
-    const modelNames = prismaClientDmmf.mappings.modelOperations.map(
-      (item) => item.model,
-    );
-    const rawOpsNames = [
-      ...new Set(
-        prismaClientDmmf.mappings.modelOperations.reduce<string[]>(
-          (result, current) => {
-            const keys = Object.keys(current);
-            keys?.forEach((key) => {
-              if (key.includes('Raw')) {
-                result.push(key);
-              }
-            });
-            return result;
-          },
-          [],
-        ),
-      ),
-    ];
-
-    rawOpsNames.forEach((opName) => {
-      modelNames.forEach((modelName) => {
-        const isFind = opName === 'findRaw';
-        const opWithModel = `${opName.replace('Raw', '')}${modelName}Raw`;
-        rawOpsMap[opWithModel] = isFind
-          ? `${modelName}FindRawArgs`
-          : `${modelName}AggregateRawArgs`;
-      });
-    });
-
-    Transformer.rawOpsMap = rawOpsMap ?? {};
-
-    const queryOutputTypes =
-      prismaClientDmmf.schema.outputObjectTypes.prisma.filter(
-        (item) => item.name === 'Query',
-      );
-
-    const mongodbRawQueries =
-      queryOutputTypes?.[0].fields.filter((field) =>
-        field.name.includes('Raw'),
-      ) ?? [];
-
-    mongodbRawQueries.forEach((item) => {
-      inputObjectTypes.push({
-        name: item.name,
-        constraints: {
-          maxNumFields: null,
-          minNumFields: null,
-        },
-        fields: item.args.map((arg) => ({
-          name: arg.name,
-          isRequired: arg.isRequired,
-          isNullable: arg.isNullable,
-          inputTypes: arg.inputTypes,
-        })),
-      });
-    });
-  }
-
+  const dataSource = options.datasources?.[0];
   Transformer.provider = dataSource.provider;
 
+  const generatorConfigOptions = options.generator.config;
+  const addMissingInputObjectTypeOptions =
+    resolveAddMissingInputObjectTypeOptions(generatorConfigOptions);
+  addMissingInputObjectTypes(
+    inputObjectTypes,
+    outputObjectTypes,
+    models,
+    modelOperations,
+    dataSource.provider,
+    addMissingInputObjectTypeOptions,
+  );
+  await generateObjectSchemas(inputObjectTypes);
+
+  await generateModelSchemas(modelOperations);
+}
+
+async function handleGeneratorOutputValue(generatorOutputValue: EnvValue) {
+  const outputDirectoryPath = parseEnvValue(generatorOutputValue);
+
+  // create the output directory and delete contents that might exist from a previous run
+  await fs.mkdir(outputDirectoryPath, { recursive: true });
+  const isRemoveContentsOnly = true;
+  await removeDir(outputDirectoryPath, isRemoveContentsOnly);
+
+  Transformer.setOutputPath(outputDirectoryPath);
+}
+
+function getGeneratorConfigByProvider(
+  generators: GeneratorConfig[],
+  provider: string,
+) {
+  return generators.find((it) => parseEnvValue(it.provider) === provider);
+}
+
+function checkForCustomPrismaClientOutputPath(
+  prismaClientGeneratorConfig: GeneratorConfig | undefined,
+) {
+  if (prismaClientGeneratorConfig?.isCustomOutput) {
+    Transformer.setPrismaClientOutputPath(
+      prismaClientGeneratorConfig.output?.value as string,
+    );
+  }
+}
+
+async function generateEnumSchemas(
+  prismaSchemaEnum: DMMF.SchemaEnum[],
+  modelSchemaEnum: DMMF.SchemaEnum[],
+) {
+  const enumTypes = [...prismaSchemaEnum, ...modelSchemaEnum];
+  const enumNames = enumTypes.map((enumItem) => enumItem.name);
+  Transformer.enumNames = enumNames ?? [];
+  const transformer = new Transformer({
+    enumTypes,
+  });
+  await transformer.generateEnumSchemas();
+}
+
+async function generateObjectSchemas(inputObjectTypes: DMMF.InputType[]) {
   for (let i = 0; i < inputObjectTypes.length; i += 1) {
     const fields = inputObjectTypes[i]?.fields;
     const name = inputObjectTypes[i]?.name;
-    const obj = new Transformer({ name, fields });
-    await obj.printObjectSchemas();
+    const transformer = new Transformer({ name, fields });
+    await transformer.generateObjectSchema();
   }
+}
 
-  const obj = new Transformer({
-    modelOperations: prismaClientDmmf.mappings.modelOperations,
+async function generateModelSchemas(modelOperations: DMMF.ModelMapping[]) {
+  const transformer = new Transformer({
+    modelOperations,
   });
-  await obj.printModelSchemas();
+  await transformer.generateModelSchemas();
 }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -54,7 +54,9 @@ export async function generate(options: GeneratorOptions) {
     );
 
     const dataSource = options.datasources?.[0];
+    const previewFeatures = prismaClientGeneratorConfig?.previewFeatures;
     Transformer.provider = dataSource.provider;
+    Transformer.previewFeatures = previewFeatures
 
     const generatorConfigOptions = options.generator.config;
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -107,6 +107,10 @@ export default class Transformer {
         inputType.type === 'Decimal'
       ) {
         result.push(this.wrapWithZodValidators('z.number()', field, inputType));
+      } else if (inputType.type === 'BigInt') {
+        result.push(
+          this.wrapWithZodValidators('z.bigint()', field, inputType),
+        );
       } else if (inputType.type === 'Boolean') {
         result.push(
           this.wrapWithZodValidators('z.boolean()', field, inputType),

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -307,6 +307,7 @@ export default class Transformer {
         findMany,
         // @ts-ignore
         createOne,
+        createMany,
         // @ts-ignore
         deleteOne,
         // @ts-ignore
@@ -372,7 +373,20 @@ export default class Transformer {
           path.join(Transformer.outputPath, `schemas/${createOne}.schema.ts`),
           `${this.getImportsForSchemas(imports)}${this.addExportSchema(
             `z.object({ data: ${modelName}CreateInputObjectSchema  })`,
-            `${modelName}Create`,
+            `${modelName}CreateOne`,
+          )}`,
+        );
+      }
+
+      if (createMany) {
+        const imports = [
+          `import { ${modelName}CreateManyInputObjectSchema } from './objects/${modelName}CreateManyInput.schema'`,
+        ];
+        await writeFileSafely(
+          path.join(Transformer.outputPath, `schemas/${createMany}.schema.ts`),
+          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
+            `z.object({ data: ${modelName}CreateManyInputObjectSchema  })`,
+            `${modelName}CreateMany`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -278,7 +278,7 @@ export default class Transformer {
       return this.wrapWithZodObject(fields) + '.strict()';
     }
 
-    const wrapped = fields.map((field) => this.wrapWithZodObject(field));
+    const wrapped = fields.map((field) => this.wrapWithZodObject(field) + '.strict()');
 
     return this.wrapWithZodOUnion(wrapped);
   }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -189,7 +189,7 @@ export default class Transformer {
       prismaClientPath = path.relative(
         path.join(Transformer.outputPath, 'schemas', 'objects'),
         prismaClientPath,
-      );
+      ).split(path.sep).join(path.posix.sep);
     }
     return `import type { Prisma } from '${prismaClientPath}';\n\n`;
   }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,7 +1,7 @@
 import type { DMMF as PrismaDMMF } from '@prisma/generator-helper';
 import path from 'path';
-import { writeFileSafely } from './utils/writeFileSafely';
 import { TransformerParams } from './types';
+import { writeFileSafely } from './utils/writeFileSafely';
 
 export default class Transformer {
   name: string;
@@ -101,7 +101,11 @@ export default class Transformer {
     let alternatives = lines.reduce<string[]>((result, inputType) => {
       if (inputType.type === 'String') {
         result.push(this.wrapWithZodValidators('z.string()', field, inputType));
-      } else if (inputType.type === 'Int' || inputType.type === 'Float') {
+      } else if (
+        inputType.type === 'Int' ||
+        inputType.type === 'Float' ||
+        inputType.type === 'Decimal'
+      ) {
         result.push(this.wrapWithZodValidators('z.number()', field, inputType));
       } else if (inputType.type === 'Boolean') {
         result.push(
@@ -186,10 +190,13 @@ export default class Transformer {
     let prismaClientPath = '@prisma/client';
     if (Transformer.isDefaultPrismaClientOutput) {
       prismaClientPath = Transformer.prismaClientOutputPath ?? '';
-      prismaClientPath = path.relative(
-        path.join(Transformer.outputPath, 'schemas', 'objects'),
-        prismaClientPath,
-      ).split(path.sep).join(path.posix.sep);
+      prismaClientPath = path
+        .relative(
+          path.join(Transformer.outputPath, 'schemas', 'objects'),
+          prismaClientPath,
+        )
+        .split(path.sep)
+        .join(path.posix.sep);
     }
     return `import type { Prisma } from '${prismaClientPath}';\n\n`;
   }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -12,6 +12,8 @@ export default class Transformer {
   static enumNames: string[] = [];
   private static outputPath: string = './generated';
   private hasJson = false;
+  static isDefaultPrismaClientOutput?: boolean;
+  static prismaClientOutputPath?: string;
 
   constructor(params: TransformerParams) {
     this.name = params.name ?? '';
@@ -181,7 +183,15 @@ export default class Transformer {
   }
 
   getImportPrisma() {
-    return `import type { Prisma } from '@prisma/client';\n\n`;
+    let prismaClientPath = '@prisma/client';
+    if (Transformer.isDefaultPrismaClientOutput) {
+      prismaClientPath = Transformer.prismaClientOutputPath ?? '';
+      prismaClientPath = path.relative(
+        path.join(Transformer.outputPath, 'schemas', 'objects'),
+        prismaClientPath,
+      );
+    }
+    return `import type { Prisma } from '${prismaClientPath}';\n\n`;
   }
 
   getJsonSchemaImplementation() {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -515,6 +515,7 @@ export default class Transformer {
           selectImport,
           includeImport,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
+          `import { ${modelName}UncheckedCreateInputObjectSchema } from './objects/${modelName}UncheckedCreateInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${createOne}.schema.ts`),
@@ -522,7 +523,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateOne`,
-            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: ${modelName}CreateInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: z.union([${modelName}CreateInputObjectSchema, ${modelName}UncheckedCreateInputObjectSchema])  })`,
           )}`,
         );
       }
@@ -579,6 +580,7 @@ export default class Transformer {
           selectImport,
           includeImport,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
+          `import { ${modelName}UncheckedUpdateInputObjectSchema } from './objects/${modelName}UncheckedUpdateInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -587,7 +589,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}UpdateOne`,
-            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: z.union([${modelName}UpdateInputObjectSchema, ${modelName}UncheckedUpdateInputObjectSchema]), where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,12 +1,12 @@
 import type {
   ConnectorType,
-  DMMF as PrismaDMMF,
+  DMMF as PrismaDMMF
 } from '@prisma/generator-helper';
 import path from 'path';
 import {
   checkModelHasModelRelation,
   findModelByName,
-  isMongodbRawOp,
+  isMongodbRawOp
 } from './helpers';
 import { isAggregateInputType } from './helpers/aggregate-helpers';
 import { AggregateOperationSupport, TransformerParams } from './types';
@@ -154,6 +154,10 @@ export default class Transformer {
       } else if (inputType.type === 'True') {
         result.push(
           this.wrapWithZodValidators('z.literal(true)', field, inputType),
+        );
+      } else if (inputType.type === 'Bytes') {
+        result.push(
+          this.wrapWithZodValidators('z.instanceof(Buffer)', field, inputType),
         );
       } else {
         const isEnum = inputType.location === 'enumTypes';

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -122,6 +122,10 @@ export default class Transformer {
         this.hasJson = true;
 
         result.push(this.wrapWithZodValidators('jsonSchema', field, inputType));
+      } else if (inputType.type === 'True') {
+        result.push(
+          this.wrapWithZodValidators('z.literal(true)', field, inputType),
+        );
       } else {
         const isEnum = inputType.location === 'enumTypes';
 
@@ -242,6 +246,9 @@ export default class Transformer {
         name = Transformer.rawOpsMap[name];
         exportName = name.replace('Args', '');
       }
+    }
+    if (name.endsWith('AggregateInput')) {
+      name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;
     return `const Schema: z.ZodType<Prisma.${name}> = ${schema};\n\n ${end}`;
@@ -504,11 +511,16 @@ export default class Transformer {
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
+          `import { ${modelName}CountAggregateInputObjectSchema } from './objects/${modelName}CountAggregateInput.schema'`,
+          `import { ${modelName}MinAggregateInputObjectSchema } from './objects/${modelName}MinAggregateInput.schema'`,
+          `import { ${modelName}MaxAggregateInputObjectSchema } from './objects/${modelName}MaxAggregateInput.schema'`,
+          `import { ${modelName}AvgAggregateInputObjectSchema } from './objects/${modelName}AvgAggregateInput.schema'`,
+          `import { ${modelName}SumAggregateInputObjectSchema } from './objects/${modelName}SumAggregateInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${aggregate}.schema.ts`),
           `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional()  })`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), _count: z.union([ z.literal(true), ${modelName}CountAggregateInputObjectSchema ]).optional(), _min: ${modelName}MinAggregateInputObjectSchema.optional(), _max: ${modelName}MaxAggregateInputObjectSchema.optional(), _avg: ${modelName}AvgAggregateInputObjectSchema.optional(), _sum: ${modelName}SumAggregateInputObjectSchema.optional()  })`,
             `${modelName}Aggregate`,
           )}`,
         );

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -716,7 +716,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}GroupBy`,
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithAggregationInputObjectSchema, ${modelName}OrderByWithAggregationInputObjectSchema.array()]).optional(), having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithAggregationInputObjectSchema, ${modelName}OrderByWithAggregationInputObjectSchema.array()]), having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -235,8 +235,8 @@ export default class Transformer {
       inputType.type === this.name
         ? objectSchemaLine
         : isEnum
-        ? enumSchemaLine
-        : objectSchemaLine;
+          ? enumSchemaLine
+          : objectSchemaLine;
 
     const arr = inputType.isList ? '.array()' : '';
 
@@ -296,22 +296,7 @@ export default class Transformer {
   addFinalWrappers({ zodStringFields }: { zodStringFields: string[] }) {
     const fields = [...zodStringFields];
 
-    const shouldWrapWithUnion = fields.some(
-      (field) =>
-        // TODO handle other cases if any
-        // field.includes('create:') ||
-        field.includes('connectOrCreate:') || field.includes('connect:'),
-    );
-
-    if (!shouldWrapWithUnion) {
-      return this.wrapWithZodObject(fields) + '.strict()';
-    }
-
-    const wrapped = fields.map(
-      (field) => this.wrapWithZodObject(field) + '.strict()',
-    );
-
-    return this.wrapWithZodUnion(wrapped);
+    return this.wrapWithZodObject(fields) + '.strict()';
   }
 
   generateImportPrismaStatement() {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -10,8 +10,8 @@ import {
 } from './helpers';
 import { isAggregateInputType } from './helpers/aggregate-helpers';
 import { AggregateOperationSupport, TransformerParams } from './types';
-import { writeIndexFile } from './utils/writeIndexFile';
 import { writeFileSafely } from './utils/writeFileSafely';
+import { writeIndexFile } from './utils/writeIndexFile';
 
 export default class Transformer {
   name: string;
@@ -65,7 +65,7 @@ export default class Transformer {
   }
 
   static async generateIndex() {
-    const indexPath = path.join(Transformer.outputPath, "schemas/index.ts");
+    const indexPath = path.join(Transformer.outputPath, 'schemas/index.ts');
     await writeIndexFile(indexPath);
   }
 
@@ -718,7 +718,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}GroupBy`,
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithAggregationInputObjectSchema, ${modelName}OrderByWithAggregationInputObjectSchema.array()]), having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithAggregationInputObjectSchema, ${modelName}OrderByWithAggregationInputObjectSchema.array()]).optional(), having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -304,7 +304,7 @@ export default class Transformer {
       name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;
-    return `const Schema: z.ZodType<Prisma.${name}> = ${schema};\n\n ${end}`;
+    return `const Schema = ${schema} satisfies z.ZodType<Prisma.${name}>;\n\n ${end}`;
   }
 
   addFinalWrappers({ zodStringFields }: { zodStringFields: string[] }) {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -616,7 +616,9 @@ export default class Transformer {
           includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
+          `import { ${modelName}UncheckedCreateInputObjectSchema } from './objects/${modelName}UncheckedCreateInput.schema'`,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
+          `import { ${modelName}UncheckedUpdateInputObjectSchema } from './objects/${modelName}UncheckedUpdateInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${upsertOne}.schema.ts`),
@@ -624,7 +626,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}Upsert`,
-            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: z.union([ ${modelName}CreateInputObjectSchema, ${modelName}UncheckedCreateInputObjectSchema ]), update: z.union([ ${modelName}UpdateInputObjectSchema, ${modelName}UncheckedUpdateInputObjectSchema ])  })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -10,13 +10,15 @@ export default class Transformer {
   schemaImports = new Set<string>();
   modelOperations: PrismaDMMF.ModelMapping[];
   enumTypes: PrismaDMMF.SchemaEnum[];
+
   static enumNames: string[] = [];
   static rawOpsMap: { [name: string]: string } = {};
   static provider: string;
   private static outputPath: string = './generated';
   private hasJson = false;
-  static isDefaultPrismaClientOutput?: boolean;
-  static prismaClientOutputPath?: string;
+  private static prismaClientOutputPath: string = '@prisma/client';
+  private static isCustomPrismaClientOutputPath: boolean = false;
+  private static isGenerateSelect: boolean = false;
 
   constructor(params: TransformerParams) {
     this.name = params.name ?? '';
@@ -29,70 +31,73 @@ export default class Transformer {
     this.outputPath = outPath;
   }
 
+  static setIsGenerateSelect(isGenerateSelect: boolean) {
+    this.isGenerateSelect = isGenerateSelect;
+  }
+
   static getOutputPath() {
     return this.outputPath;
   }
 
-  addSchemaImport(name: string) {
-    this.schemaImports.add(name);
+  static setPrismaClientOutputPath(prismaClientCustomPath: string) {
+    this.prismaClientOutputPath = prismaClientCustomPath;
+    this.isCustomPrismaClientOutputPath =
+      prismaClientCustomPath !== '@prisma/client';
   }
 
-  getAllSchemaImports() {
-    return [...this.schemaImports]
-      .map((name) =>
-        Transformer.enumNames.includes(name)
-          ? `import { ${name}Schema } from '../enums/${name}.schema';`
-          : `import { ${name}ObjectSchema } from './${name}.schema';`,
-      )
-      .join(';\r\n');
-  }
+  async generateEnumSchemas() {
+    for (const enumType of this.enumTypes) {
+      const { name, values } = enumType;
 
-  getPrismaStringLine(
-    field: PrismaDMMF.SchemaArg,
-    inputType: PrismaDMMF.SchemaArgInputType,
-    inputsLength: number,
-  ) {
-    const isEnum = inputType.location === 'enumTypes';
-
-    let objectSchemaLine = `${inputType.type}ObjectSchema`;
-    let enumSchemaLine = `${inputType.type}Schema`;
-
-    const schema =
-      inputType.type === this.name
-        ? objectSchemaLine
-        : isEnum
-        ? enumSchemaLine
-        : objectSchemaLine;
-
-    const arr = inputType.isList ? '.array()' : '';
-
-    const opt = !field.isRequired ? '.optional()' : '';
-
-    return inputsLength === 1
-      ? `  ${field.name}: z.lazy(() => ${schema})${arr}${opt}`
-      : `z.lazy(() => ${schema})${arr}${opt}`;
-  }
-
-  wrapWithZodValidators(
-    mainValidator: string,
-    field: PrismaDMMF.SchemaArg,
-    inputType: PrismaDMMF.SchemaArgInputType,
-  ) {
-    let line: string = '';
-    line = mainValidator;
-
-    if (inputType.isList) {
-      line += '.array()';
+      await writeFileSafely(
+        path.join(Transformer.outputPath, `schemas/enums/${name}.schema.ts`),
+        `${this.generateImportZodStatement()}\n${this.generateExportSchemaStatement(
+          `${name}`,
+          `z.enum(${JSON.stringify(values)})`,
+        )}`,
+      );
     }
-
-    if (!field.isRequired) {
-      line += '.optional()';
-    }
-
-    return line;
   }
 
-  getObjectSchemaLine(
+  generateImportZodStatement() {
+    return "import { z } from 'zod';\n";
+  }
+
+  generateExportSchemaStatement(name: string, schema: string) {
+    return `export const ${name}Schema = ${schema}`;
+  }
+
+  async generateObjectSchema() {
+    const zodObjectSchemaFields = this.generateObjectSchemaFields();
+    const objectSchema = this.prepareObjectSchema(zodObjectSchemaFields);
+    const objectSchemaName = this.resolveObjectSchemaName();
+
+    await writeFileSafely(
+      path.join(
+        Transformer.outputPath,
+        `schemas/objects/${objectSchemaName}.schema.ts`,
+      ),
+      objectSchema,
+    );
+  }
+
+  generateObjectSchemaFields() {
+    const zodObjectSchemaFields = this.fields
+      .map((field) => this.generateObjectSchemaField(field))
+      .flatMap((item) => item)
+      .map((item) => {
+        const [zodStringWithMainType, field, skipValidators] = item;
+
+        const value = skipValidators
+          ? zodStringWithMainType
+          : this.generateFieldValidators(zodStringWithMainType, field);
+
+        return value.trim();
+      });
+    return zodObjectSchemaFields;
+  }
+
+  generateObjectSchemaField(
     field: PrismaDMMF.SchemaArg,
   ): [string, PrismaDMMF.SchemaArg, boolean][] {
     let lines = field.inputTypes;
@@ -137,7 +142,9 @@ export default class Transformer {
             this.addSchemaImport(inputType.type);
           }
 
-          result.push(this.getPrismaStringLine(field, inputType, lines.length));
+          result.push(
+            this.generatePrismaStringLine(field, inputType, lines.length),
+          );
         }
       }
 
@@ -172,7 +179,61 @@ export default class Transformer {
     return [[`  ${fieldName} ${resString} `, field, true]];
   }
 
-  getFieldValidators(
+  wrapWithZodValidators(
+    mainValidator: string,
+    field: PrismaDMMF.SchemaArg,
+    inputType: PrismaDMMF.SchemaArgInputType,
+  ) {
+    let line: string = '';
+    line = mainValidator;
+
+    if (inputType.isList) {
+      line += '.array()';
+    }
+
+    if (!field.isRequired) {
+      line += '.optional()';
+    }
+
+    return line;
+  }
+
+  addSchemaImport(name: string) {
+    this.schemaImports.add(name);
+  }
+
+  generatePrismaStringLine(
+    field: PrismaDMMF.SchemaArg,
+    inputType: PrismaDMMF.SchemaArgInputType,
+    inputsLength: number,
+  ) {
+    const isEnum = inputType.location === 'enumTypes';
+
+    const { isModelQueryType, modelName, queryName } =
+      this.checkIsModelQueryType(inputType.type as string);
+
+    let objectSchemaLine = isModelQueryType
+      ? this.resolveModelQuerySchemaName(modelName!, queryName!)
+      : `${inputType.type}ObjectSchema`;
+    let enumSchemaLine = `${inputType.type}Schema`;
+
+    const schema =
+      inputType.type === this.name
+        ? objectSchemaLine
+        : isEnum
+        ? enumSchemaLine
+        : objectSchemaLine;
+
+    const arr = inputType.isList ? '.array()' : '';
+
+    const opt = !field.isRequired ? '.optional()' : '';
+
+    return inputsLength === 1
+      ? `  ${field.name}: z.lazy(() => ${schema})${arr}${opt}`
+      : `z.lazy(() => ${schema})${arr}${opt}`;
+  }
+
+  generateFieldValidators(
     zodStringWithMainType: string,
     field: PrismaDMMF.SchemaArg,
   ) {
@@ -189,56 +250,19 @@ export default class Transformer {
     return zodStringWithMainType;
   }
 
-  getImportZod() {
-    let zodImportStatement = "import { z } from 'zod';";
-    zodImportStatement += '\n';
-    return zodImportStatement;
+  prepareObjectSchema(zodObjectSchemaFields: string[]) {
+    const objectSchema = `${this.generateExportObjectSchemaStatement(
+      this.addFinalWrappers({ zodStringFields: zodObjectSchemaFields }),
+    )}\n`;
+
+    const prismaImportStatement = this.generateImportPrismaStatement();
+
+    const json = this.generateJsonSchemaImplementation();
+
+    return `${this.generateObjectSchemaImportStatements()}${prismaImportStatement}${json}${objectSchema}`;
   }
 
-  getImportPrisma() {
-    let prismaClientPath = '@prisma/client';
-    if (Transformer.isDefaultPrismaClientOutput) {
-      prismaClientPath = Transformer.prismaClientOutputPath ?? '';
-      prismaClientPath = path
-        .relative(
-          path.join(Transformer.outputPath, 'schemas', 'objects'),
-          prismaClientPath,
-        )
-        .split(path.sep)
-        .join(path.posix.sep);
-    }
-    return `import type { Prisma } from '${prismaClientPath}';\n\n`;
-  }
-
-  getJsonSchemaImplementation() {
-    let jsonSchemaImplementation = '';
-
-    if (this.hasJson) {
-      jsonSchemaImplementation += `\n`;
-      jsonSchemaImplementation += `const literalSchema = z.union([z.string(), z.number(), z.boolean()]);\n`;
-      jsonSchemaImplementation += `const jsonSchema: z.ZodType<Prisma.InputJsonValue> = z.lazy(() =>\n`;
-      jsonSchemaImplementation += `  z.union([literalSchema, z.array(jsonSchema.nullable()), z.record(jsonSchema.nullable())])\n`;
-      jsonSchemaImplementation += `);\n\n`;
-    }
-
-    return jsonSchemaImplementation;
-  }
-
-  getImportsForObjectSchemas() {
-    let imports = this.getImportZod();
-    imports += this.getAllSchemaImports();
-    imports += '\n\n';
-    return imports;
-  }
-
-  getImportsForSchemas(additionalImports: string[]) {
-    let imports = this.getImportZod();
-    imports += [...additionalImports].join(';\r\n');
-    imports += '\n\n';
-    return imports;
-  }
-
-  addExportObjectSchema(schema: string) {
+  generateExportObjectSchemaStatement(schema: string) {
     let name = this.name;
     let exportName = this.name;
     if (Transformer.provider === 'mongodb') {
@@ -252,32 +276,6 @@ export default class Transformer {
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;
     return `const Schema: z.ZodType<Prisma.${name}> = ${schema};\n\n ${end}`;
-  }
-
-  addExportSchema(schema: string, name: string) {
-    return `export const ${name}Schema = ${schema}`;
-  }
-
-  wrapWithZodObject(zodStringFields: string | string[]) {
-    let wrapped = '';
-
-    wrapped += 'z.object({';
-    wrapped += '\n';
-    wrapped += '  ' + zodStringFields;
-    wrapped += '\n';
-    wrapped += '})';
-    return wrapped;
-  }
-
-  wrapWithZodOUnion(zodStringFields: string[]) {
-    let wrapped = '';
-
-    wrapped += 'z.union([';
-    wrapped += '\n';
-    wrapped += '  ' + zodStringFields.join(',');
-    wrapped += '\n';
-    wrapped += '])';
-    return wrapped;
   }
 
   addFinalWrappers({ zodStringFields }: { zodStringFields: string[] }) {
@@ -298,53 +296,131 @@ export default class Transformer {
       (field) => this.wrapWithZodObject(field) + '.strict()',
     );
 
-    return this.wrapWithZodOUnion(wrapped);
+    return this.wrapWithZodUnion(wrapped);
   }
 
-  getFinalForm(zodStringFields: string[]) {
-    const objectSchema = `${this.addExportObjectSchema(
-      this.addFinalWrappers({ zodStringFields }),
-    )}\n`;
-
-    const prismaImport = this.getImportPrisma();
-
-    const json = this.getJsonSchemaImplementation();
-
-    return `${this.getImportsForObjectSchemas()}${prismaImport}${json}${objectSchema}`;
+  generateImportPrismaStatement() {
+    let prismaClientImportPath: string;
+    if (Transformer.isCustomPrismaClientOutputPath) {
+      /**
+       * If a custom location was designated for the prisma client, we need to figure out the
+       * relative path from {outputPath}/schemas/objects to {prismaClientCustomPath}
+       */
+      const fromPath = path.join(Transformer.outputPath, 'schemas', 'objects');
+      const toPath = Transformer.prismaClientOutputPath!;
+      const relativePathFromOutputToPrismaClient = path
+        .relative(fromPath, toPath)
+        .split(path.sep)
+        .join(path.posix.sep);
+      prismaClientImportPath = relativePathFromOutputToPrismaClient;
+    } else {
+      /**
+       * If the default output path for prisma client (@prisma/client) is being used, we can import from it directly
+       * without having to resolve a relative path
+       */
+      prismaClientImportPath = Transformer.prismaClientOutputPath;
+    }
+    return `import type { Prisma } from '${prismaClientImportPath}';\n\n`;
   }
 
-  async printObjectSchemas() {
-    const zodStringFields = this.fields
-      .map((field) => this.getObjectSchemaLine(field))
-      .flatMap((item) => item)
-      .map((item) => {
-        const [zodStringWithMainType, field, skipValidators] = item;
+  generateJsonSchemaImplementation() {
+    let jsonSchemaImplementation = '';
 
-        const value = skipValidators
-          ? zodStringWithMainType
-          : this.getFieldValidators(zodStringWithMainType, field);
+    if (this.hasJson) {
+      jsonSchemaImplementation += `\n`;
+      jsonSchemaImplementation += `const literalSchema = z.union([z.string(), z.number(), z.boolean()]);\n`;
+      jsonSchemaImplementation += `const jsonSchema: z.ZodType<Prisma.InputJsonValue> = z.lazy(() =>\n`;
+      jsonSchemaImplementation += `  z.union([literalSchema, z.array(jsonSchema.nullable()), z.record(jsonSchema.nullable())])\n`;
+      jsonSchemaImplementation += `);\n\n`;
+    }
 
-        return value.trim();
-      });
+    return jsonSchemaImplementation;
+  }
 
+  generateObjectSchemaImportStatements() {
+    let generatedImports = this.generateImportZodStatement();
+    generatedImports += this.generateSchemaImports();
+    generatedImports += '\n\n';
+    return generatedImports;
+  }
+
+  generateSchemaImports() {
+    return [...this.schemaImports]
+      .map((name) => {
+        const { isModelQueryType, modelName, queryName } =
+          this.checkIsModelQueryType(name);
+        if (isModelQueryType) {
+          return `import { ${this.resolveModelQuerySchemaName(
+            modelName!,
+            queryName!,
+          )} } from '../${queryName}${modelName}.schema'`;
+        } else if (Transformer.enumNames.includes(name)) {
+          return `import { ${name}Schema } from '../enums/${name}.schema'`;
+        } else {
+          return `import { ${name}ObjectSchema } from './${name}.schema'`;
+        }
+      })
+      .join(';\r\n');
+  }
+
+  checkIsModelQueryType(type: string) {
+    const modelQueryTypeSuffixToQueryName: Record<string, string> = {
+      FindManyArgs: 'findMany',
+    };
+    for (const modelQueryType of ['FindManyArgs']) {
+      if (type.includes(modelQueryType)) {
+        const modelQueryTypeSuffixIndex = type.indexOf(modelQueryType);
+        return {
+          isModelQueryType: true,
+          modelName: type.substring(0, modelQueryTypeSuffixIndex),
+          queryName: modelQueryTypeSuffixToQueryName[modelQueryType],
+        };
+      }
+    }
+    return { isModelQueryType: false };
+  }
+
+  resolveModelQuerySchemaName(modelName: string, queryName: string) {
+    const modelNameCapitalized =
+      modelName.charAt(0).toUpperCase() + modelName.slice(1);
+    const queryNameCapitalized =
+      queryName.charAt(0).toUpperCase() + queryName!.slice(1);
+    return `${modelNameCapitalized}${queryNameCapitalized}Schema`;
+  }
+
+  wrapWithZodUnion(zodStringFields: string[]) {
+    let wrapped = '';
+
+    wrapped += 'z.union([';
+    wrapped += '\n';
+    wrapped += '  ' + zodStringFields.join(',');
+    wrapped += '\n';
+    wrapped += '])';
+    return wrapped;
+  }
+
+  wrapWithZodObject(zodStringFields: string | string[]) {
+    let wrapped = '';
+
+    wrapped += 'z.object({';
+    wrapped += '\n';
+    wrapped += '  ' + zodStringFields;
+    wrapped += '\n';
+    wrapped += '})';
+    return wrapped;
+  }
+
+  resolveObjectSchemaName() {
     let name = this.name;
     let exportName = this.name;
     if (isMongodbRawOp(name)) {
       name = Transformer.rawOpsMap[name];
       exportName = name.replace('Args', '');
     }
-
-    await writeFileSafely(
-      path.join(
-        Transformer.outputPath,
-        `schemas/objects/${exportName}.schema.ts`,
-      ),
-
-      this.getFinalForm(zodStringFields),
-    );
+    return exportName;
   }
 
-  async printModelSchemas() {
+  async generateModelSchemas() {
     for (const model of this.modelOperations) {
       const {
         model: modelName,
@@ -366,21 +442,28 @@ export default class Transformer {
         groupBy,
       } = model;
 
+      const { selectImport, selectZodSchemaLine, selectZodSchemaLineLazy } =
+        this.resolveSelectImportAndZodSchemaLine(modelName);
+
       if (findUnique) {
         const imports = [
+          selectImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${findUnique}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereUniqueInputObjectSchema })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}FindUnique`,
+            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema })`,
           )}`,
         );
       }
 
       if (findFirst) {
         const imports = [
+          selectImport,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -388,15 +471,18 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${findFirst}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}FindFirst`,
+            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
           )}`,
         );
       }
 
       if (findMany) {
         const imports = [
+          selectImport,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -404,22 +490,27 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${findMany}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}FindMany`,
+            `z.object({ ${selectZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
           )}`,
         );
       }
 
       if (createOne) {
         const imports = [
+          selectImport,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${createOne}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ data: ${modelName}CreateInputObjectSchema  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}CreateOne`,
+            `z.object({ ${selectZodSchemaLine} data: ${modelName}CreateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -430,22 +521,27 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${createMany}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ data: ${modelName}CreateManyInputObjectSchema  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}CreateMany`,
+            `z.object({ data: ${modelName}CreateManyInputObjectSchema  })`,
           )}`,
         );
       }
 
       if (deleteOne) {
         const imports = [
+          selectImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${deleteOne}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereUniqueInputObjectSchema  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}DeleteOne`,
+            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -456,23 +552,28 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${deleteMany}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional()  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}DeleteMany`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional()  })`,
           )}`,
         );
       }
 
       if (updateOne) {
         const imports = [
+          selectImport,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${updateOne}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}UpdateOne`,
+            `z.object({ ${selectZodSchemaLine} data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -484,24 +585,29 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${updateMany}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ data: ${modelName}UpdateManyMutationInputObjectSchema, where: ${modelName}WhereInputObjectSchema.optional()  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}UpdateMany`,
+            `z.object({ data: ${modelName}UpdateManyMutationInputObjectSchema, where: ${modelName}WhereInputObjectSchema.optional()  })`,
           )}`,
         );
       }
 
       if (upsertOne) {
         const imports = [
+          selectImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${upsertOne}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}Upsert`,
+            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -519,9 +625,11 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${aggregate}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), _count: z.union([ z.literal(true), ${modelName}CountAggregateInputObjectSchema ]).optional(), _min: ${modelName}MinAggregateInputObjectSchema.optional(), _max: ${modelName}MaxAggregateInputObjectSchema.optional(), _avg: ${modelName}AvgAggregateInputObjectSchema.optional(), _sum: ${modelName}SumAggregateInputObjectSchema.optional()  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}Aggregate`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), _count: z.union([ z.literal(true), ${modelName}CountAggregateInputObjectSchema ]).optional(), _min: ${modelName}MinAggregateInputObjectSchema.optional(), _max: ${modelName}MaxAggregateInputObjectSchema.optional(), _avg: ${modelName}AvgAggregateInputObjectSchema.optional(), _sum: ${modelName}SumAggregateInputObjectSchema.optional()  })`,
           )}`,
         );
       }
@@ -535,26 +643,37 @@ export default class Transformer {
         ];
         await writeFileSafely(
           path.join(Transformer.outputPath, `schemas/${groupBy}.schema.ts`),
-          `${this.getImportsForSchemas(imports)}${this.addExportSchema(
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithAggregationInputObjectSchema, having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
+          `${this.generateImportStatements(
+            imports,
+          )}${this.generateExportSchemaStatement(
             `${modelName}GroupBy`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithAggregationInputObjectSchema, having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
           )}`,
         );
       }
     }
   }
 
-  async printEnumSchemas() {
-    for (const enumType of this.enumTypes) {
-      const { name, values } = enumType;
+  generateImportStatements(imports: (string | undefined)[]) {
+    let generatedImports = this.generateImportZodStatement();
+    generatedImports +=
+      imports?.filter((importItem) => !!importItem).join(';\r\n') ?? '';
+    generatedImports += '\n\n';
+    return generatedImports;
+  }
 
-      await writeFileSafely(
-        path.join(Transformer.outputPath, `schemas/enums/${name}.schema.ts`),
-        `${this.getImportZod()}\n${this.addExportSchema(
-          `z.enum(${JSON.stringify(values)})`,
-          `${name}`,
-        )}`,
-      );
+  resolveSelectImportAndZodSchemaLine(modelName: string) {
+    const selectImport = Transformer.isGenerateSelect
+      ? `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`
+      : '';
+
+    let selectZodSchemaLine = '';
+    let selectZodSchemaLineLazy = '';
+    if (Transformer.isGenerateSelect) {
+      let zodSelectObjectSchema = `${modelName}SelectObjectSchema.optional()`;
+      selectZodSchemaLine = `select: ${zodSelectObjectSchema},`;
+      selectZodSchemaLineLazy = `select: z.lazy(() => ${zodSelectObjectSchema}),`;
     }
+    return { selectImport, selectZodSchemaLine, selectZodSchemaLineLazy };
   }
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import {
   checkModelHasModelRelation,
   findModelByName,
-  isMongodbRawOp,
+  isMongodbRawOp
 } from './helpers';
 import { isAggregateInputType } from './helpers/aggregate-helpers';
 import { AggregateOperationSupport, TransformerParams } from './types';
@@ -500,7 +500,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindFirst`,
-            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithRelationInputObjectSchema, ${modelName}OrderByWithRelationInputObjectSchema.array()]).optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
           )}`,
         );
       }
@@ -520,7 +520,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindMany`,
-            `z.object({ ${selectZodSchemaLineLazy} ${includeZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
+            `z.object({ ${selectZodSchemaLineLazy} ${includeZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithRelationInputObjectSchema, ${modelName}OrderByWithRelationInputObjectSchema.array()]).optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
           )}`,
         );
       }
@@ -696,7 +696,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}Aggregate`,
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), ${aggregateOperations.join(
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithRelationInputObjectSchema, ${modelName}OrderByWithRelationInputObjectSchema.array()]).optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), ${aggregateOperations.join(
               ', ',
             )} })`,
           )}`,
@@ -716,7 +716,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}GroupBy`,
-            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithAggregationInputObjectSchema, having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
+            `z.object({ where: ${modelName}WhereInputObjectSchema.optional(), orderBy: z.union([${modelName}OrderByWithAggregationInputObjectSchema, ${modelName}OrderByWithAggregationInputObjectSchema.array()]).optional(), having: ${modelName}ScalarWhereWithAggregatesInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), by: z.array(${modelName}ScalarFieldEnumSchema)  })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -551,7 +551,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateMany`,
-            `z.object({ data: ${modelName}CreateManyInputObjectSchema  })`,
+            `z.object({ data: z.union([ ${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema) ]) })`,
           )}`,
         );
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -271,7 +271,14 @@ export default class Transformer {
         exportName = name.replace('Args', '');
       }
     }
-    if (name.endsWith('AggregateInput')) {
+
+    if (
+      name.endsWith('CountAggregateInput') ||
+      name.endsWith('SumAggregateInput') ||
+      name.endsWith('AvgAggregateInput') ||
+      name.endsWith('MinAggregateInput') ||
+      name.endsWith('MaxAggregateInput')
+    ) {
       name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -19,6 +19,7 @@ export default class Transformer {
   private static prismaClientOutputPath: string = '@prisma/client';
   private static isCustomPrismaClientOutputPath: boolean = false;
   private static isGenerateSelect: boolean = false;
+  private static isGenerateInclude: boolean = false;
 
   constructor(params: TransformerParams) {
     this.name = params.name ?? '';
@@ -33,6 +34,10 @@ export default class Transformer {
 
   static setIsGenerateSelect(isGenerateSelect: boolean) {
     this.isGenerateSelect = isGenerateSelect;
+  }
+
+  static setIsGenerateInclude(isGenerateInclude: boolean) {
+    this.isGenerateInclude = isGenerateInclude;
   }
 
   static getOutputPath() {
@@ -449,12 +454,19 @@ export default class Transformer {
         groupBy,
       } = model;
 
-      const { selectImport, selectZodSchemaLine, selectZodSchemaLineLazy } =
-        this.resolveSelectImportAndZodSchemaLine(modelName);
+      const {
+        selectImport,
+        includeImport,
+        selectZodSchemaLine,
+        includeZodSchemaLine,
+        selectZodSchemaLineLazy,
+        includeZodSchemaLineLazy,
+      } = this.resolveSelectIncludeImportAndZodSchemaLine(modelName);
 
       if (findUnique) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -463,7 +475,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindUnique`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema })`,
           )}`,
         );
       }
@@ -471,6 +483,7 @@ export default class Transformer {
       if (findFirst) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -482,7 +495,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindFirst`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional() })`,
           )}`,
         );
       }
@@ -490,6 +503,7 @@ export default class Transformer {
       if (findMany) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
           `import { ${modelName}OrderByWithRelationInputObjectSchema } from './objects/${modelName}OrderByWithRelationInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
@@ -501,7 +515,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}FindMany`,
-            `z.object({ ${selectZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
+            `z.object({ ${selectZodSchemaLineLazy} ${includeZodSchemaLineLazy} where: ${modelName}WhereInputObjectSchema.optional(), orderBy: ${modelName}OrderByWithRelationInputObjectSchema.optional(), cursor: ${modelName}WhereUniqueInputObjectSchema.optional(), take: z.number().optional(), skip: z.number().optional(), distinct: z.array(${modelName}ScalarFieldEnumSchema).optional()  })`,
           )}`,
         );
       }
@@ -509,6 +523,7 @@ export default class Transformer {
       if (createOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
         ];
         await writeFileSafely(
@@ -517,7 +532,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateOne`,
-            `z.object({ ${selectZodSchemaLine} data: ${modelName}CreateInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: ${modelName}CreateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -540,6 +555,7 @@ export default class Transformer {
       if (deleteOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
@@ -548,7 +564,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}DeleteOne`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -571,6 +587,7 @@ export default class Transformer {
       if (updateOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
@@ -580,7 +597,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}UpdateOne`,
-            `z.object({ ${selectZodSchemaLine} data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} data: ${modelName}UpdateInputObjectSchema, where: ${modelName}WhereUniqueInputObjectSchema  })`,
           )}`,
         );
       }
@@ -604,6 +621,7 @@ export default class Transformer {
       if (upsertOne) {
         const imports = [
           selectImport,
+          includeImport,
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
           `import { ${modelName}CreateInputObjectSchema } from './objects/${modelName}CreateInput.schema'`,
           `import { ${modelName}UpdateInputObjectSchema } from './objects/${modelName}UpdateInput.schema'`,
@@ -614,7 +632,7 @@ export default class Transformer {
             imports,
           )}${this.generateExportSchemaStatement(
             `${modelName}Upsert`,
-            `z.object({ ${selectZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
+            `z.object({ ${selectZodSchemaLine} ${includeZodSchemaLine} where: ${modelName}WhereUniqueInputObjectSchema, create: ${modelName}CreateInputObjectSchema, update: ${modelName}UpdateInputObjectSchema  })`,
           )}`,
         );
       }
@@ -669,18 +687,35 @@ export default class Transformer {
     return generatedImports;
   }
 
-  resolveSelectImportAndZodSchemaLine(modelName: string) {
+  resolveSelectIncludeImportAndZodSchemaLine(modelName: string) {
     const selectImport = Transformer.isGenerateSelect
       ? `import { ${modelName}SelectObjectSchema } from './objects/${modelName}Select.schema'`
       : '';
+    const includeImport = Transformer.isGenerateInclude
+      ? `import { ${modelName}IncludeObjectSchema } from './objects/${modelName}Include.schema'`
+      : '';
 
     let selectZodSchemaLine = '';
+    let includeZodSchemaLine = '';
     let selectZodSchemaLineLazy = '';
+    let includeZodSchemaLineLazy = '';
     if (Transformer.isGenerateSelect) {
-      let zodSelectObjectSchema = `${modelName}SelectObjectSchema.optional()`;
+      const zodSelectObjectSchema = `${modelName}SelectObjectSchema.optional()`;
       selectZodSchemaLine = `select: ${zodSelectObjectSchema},`;
       selectZodSchemaLineLazy = `select: z.lazy(() => ${zodSelectObjectSchema}),`;
     }
-    return { selectImport, selectZodSchemaLine, selectZodSchemaLineLazy };
+    if (Transformer.isGenerateInclude) {
+      const zodIncludeObjectSchema = `${modelName}IncludeObjectSchema.optional()`;
+      includeZodSchemaLine = `include: ${zodIncludeObjectSchema},`;
+      includeZodSchemaLineLazy = `include: z.lazy(() => ${zodIncludeObjectSchema}),`;
+    }
+    return {
+      selectImport,
+      includeImport,
+      selectZodSchemaLine,
+      includeZodSchemaLine,
+      selectZodSchemaLineLazy,
+      includeZodSchemaLineLazy,
+    };
   }
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -10,6 +10,7 @@ import {
 } from './helpers';
 import { isAggregateInputType } from './helpers/aggregate-helpers';
 import { AggregateOperationSupport, TransformerParams } from './types';
+import { writeIndexFile } from './utils/writeIndexFile';
 import { writeFileSafely } from './utils/writeFileSafely';
 
 export default class Transformer {
@@ -61,6 +62,11 @@ export default class Transformer {
     this.prismaClientOutputPath = prismaClientCustomPath;
     this.isCustomPrismaClientOutputPath =
       prismaClientCustomPath !== '@prisma/client';
+  }
+
+  static async generateIndex() {
+    const indexPath = path.join(Transformer.outputPath, "schemas/index.ts");
+    await writeIndexFile(indexPath);
   }
 
   async generateEnumSchemas() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,6 @@ export type TransformerParams = {
   fields?: PrismaDMMF.SchemaArg[];
   name?: string;
   modelOperations?: PrismaDMMF.ModelMapping[];
+  isDefaultPrismaClientOutput?: boolean;
+  prismaClientOutputPath?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type TransformerParams = {
   enumTypes?: PrismaDMMF.SchemaEnum[];
   fields?: PrismaDMMF.SchemaArg[];
   name?: string;
+  models?: PrismaDMMF.Model[];
   modelOperations?: PrismaDMMF.ModelMapping[];
   isDefaultPrismaClientOutput?: boolean;
   prismaClientOutputPath?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,17 @@ export type TransformerParams = {
   name?: string;
   models?: PrismaDMMF.Model[];
   modelOperations?: PrismaDMMF.ModelMapping[];
+  aggregateOperationSupport?: AggregateOperationSupport;
   isDefaultPrismaClientOutput?: boolean;
   prismaClientOutputPath?: string;
+};
+
+export type AggregateOperationSupport = {
+  [model: string]: {
+    count?: boolean;
+    min?: boolean;
+    max?: boolean;
+    sum?: boolean;
+    avg?: boolean;
+  };
 };

--- a/src/utils/writeFileSafely.ts
+++ b/src/utils/writeFileSafely.ts
@@ -1,11 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 import { formatFile } from './formatFile';
+import { addIndexExport } from './writeIndexFile';
 
-export const writeFileSafely = async (writeLocation: string, content: any) => {
+export const writeFileSafely = async (writeLocation: string, content: any, addToIndex = true) => {
   fs.mkdirSync(path.dirname(writeLocation), {
     recursive: true,
   });
 
   fs.writeFileSync(writeLocation, await formatFile(content));
+
+  if (addToIndex) {
+    addIndexExport(writeLocation);
+  }
 };

--- a/src/utils/writeIndexFile.ts
+++ b/src/utils/writeIndexFile.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+import { writeFileSafely } from './writeFileSafely';
+
+const indexExports = new Set<string>();
+
+export const addIndexExport = (filePath: string) => {
+  indexExports.add(filePath);
+}
+
+function normalizePath(path: string) {
+  if (typeof path !== 'string') {
+    throw new TypeError('Expected argument path to be a string');
+  }
+  if (path === '\\' || path === '/') return '/';
+
+  let len = path.length;
+  if (len <= 1) return path;
+  let prefix = '';
+  if (len > 4 && path[3] === '\\') {
+    let ch = path[2];
+    if ((ch === '?' || ch === '.') && path.slice(0, 2) === '\\\\') {
+      path = path.slice(2);
+      prefix = '//';
+    }
+  }
+
+  let segs = path.split(/[/\\]+/);
+  return prefix + segs.join('/');
+};
+
+
+export const writeIndexFile = async (indexPath: string) => {
+  const rows = Array.from(indexExports).map((filePath) => {
+    let relativePath = path.relative(path.dirname(indexPath), filePath);
+    if (relativePath.endsWith('.ts')) {
+      relativePath = relativePath.slice(0, relativePath.lastIndexOf('.ts'))
+    }
+    const normalized = normalizePath(relativePath);
+    return `export * from './${normalized}'`;
+  });
+  const content = rows.join('\n');
+  await writeFileSafely(indexPath, content, false);
+}


### PR DESCRIPTION

### Description

Currently the object schemas look like `const Schema: z.ZodType<> = ...`;

As mentioned in #64 this causes properties to go missing. However, that PR suggests removing this annotation which @omar-dulaimi states causes problems with tRPC.

This PR uses the `satisfies` operator to provide the type information instead. I am using this approach in a tRPC project without an issue.

### References

Compare the difference in explicit type annotation vs `satisfies` here:

<img width="623" alt="image" src="https://user-images.githubusercontent.com/22670878/236316429-acab14b2-2fd3-4c04-a7fb-71d7d5a6d646.png">


https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgLzgXzgMyhEcDkyEAJvgNxxwD0VcMAnmAKYDOAXHAMwB0ATAIzcALACgRTAB6RYdRkzgBVFkygBhKEwCGMeQF5EIysGIcWMKMAB2Ac0NxLmkEwD8p81dtoxAYwiWzispqGtpMAMreABZMIJoAWiQAKnIcyNwJxMnMADxKKupaOgB8cPppEABGAFZM3jAAFAh2xqncZhY29QCUADR2Dk6t7R7d3BBgMMB+mgA23X1oXWJ5wYXhUTHxSXJjIMAwdpRHxycnNHAAes4+fgErBaER0bFh2sAsmMCspShj1bUNJpGEy-YadXr9RxMIbucFjCZTBxzCGLOAsN4fL4sX4ZLJMXJBB7FZaEkI6J6bV6TTGsXb7Q6nRmM85XERAA