### PR TITLE
Resolves #88 - satisfies type instead of inferring

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -306,7 +306,7 @@ export default class Transformer {
       name = `${name}Type`;
     }
     const end = `export const ${exportName}ObjectSchema = Schema`;
-    return `const Schema: z.ZodType<Prisma.${name}> = ${schema};\n\n ${end}`;
+    return `const Schema = ${schema} satisfies z.ZodType<Prisma.${name}>;\n\n ${end}`;
   }
 
   addFinalWrappers({ zodStringFields }: { zodStringFields: string[] }) {


### PR DESCRIPTION
### Description

See #88 in reference to the issue. This implements the `satisfies` keyword for the type instead of inferring the zodType directly.

```typescript
import { z } from 'zod';

import type { Prisma } from '@prisma/client';

const Schema = z
  .object({
    id: z.number().optional(),
    email: z.string().optional(),
  })
  .strict() satisfies z.ZodType<Prisma.UserWhereUniqueInput>;

export const UserWhereUniqueInputObjectSchema = Schema;
```

With the above, you can now

```typescript
const ExtendedSchema = UserWhereUniqueInputObjectSchema.extend({
  example: z.string()
})
// And
const ExampleSchema = UserWhereUniqueInputObjectSchema.shape.example;
```

### References

Fixes #88. And a similar discussion in the [zod repo](https://github.com/colinhacks/zod/discussions/1886#discussioncomment-4686267).