### PR TITLE
Add `useDecimalLib` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ model User {
 | `output`            | Output directory for the generated zod schemas                             | `string`  | `./generated` |
 | `isGenerateSelect`  | Enables the generation of Select related schemas and the select property   | `boolean` | `false`       |
 | `isGenerateInclude` | Enables the generation of Include related schemas and the include property | `boolean` | `false`       |
+| `useDecimalLib`     | Treat Decimal values as instances of Decimal library instead of numbers    | `boolean` | `false`       |
 
+|
 Use additional options in the `schema.prisma`
 
 ```prisma
@@ -136,5 +138,6 @@ generator zod {
   output            = "./generated-zod-schemas"
   isGenerateSelect  = true
   isGenerateInclude = true
+  useDecimalLib     = true
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@types/node": "^18.11.18",
         "@types/prettier": "^2.7.2",
+        "decimal.js": "^10.4.3",
         "prisma": "^4.8.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
@@ -819,6 +820,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
     },
     "node_modules/del": {
       "version": "6.1.1",
@@ -3417,6 +3424,12 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
     },
     "del": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@types/node": "^18.11.18",
     "@types/prettier": "^2.7.2",
+    "decimal.js": "^10.4.3",
     "prisma": "^4.8.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,14 +12,16 @@ generator zod {
   output            = "./generated"
   isGenerateSelect  = true
   isGenerateInclude = true
+  useDecimalLib     = true
 }
 
 model User {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
-  posts Post[]
-  books Book[]
+  id     Int     @id @default(autoincrement())
+  email  String  @unique
+  name   String?
+  posts  Post[]
+  books  Book[]
+  rating Decimal
 }
 
 model Post {

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -10,6 +10,7 @@ import { changeOptionalToRequiredFields } from './whereUniqueInput-helpers';
 interface AddMissingInputObjectTypeOptions {
   isGenerateSelect: boolean;
   isGenerateInclude: boolean;
+  useDecimalLib: boolean;
 }
 
 export function addMissingInputObjectTypes(
@@ -53,6 +54,7 @@ export function addMissingInputObjectTypes(
     );
     Transformer.setIsGenerateInclude(true);
   }
+  Transformer.setUseDecimalLib(options.useDecimalLib);
 
   changeOptionalToRequiredFields(inputObjectTypes);
 }
@@ -63,5 +65,6 @@ export function resolveAddMissingInputObjectTypeOptions(
   return {
     isGenerateSelect: generatorConfigOptions.isGenerateSelect === 'true',
     isGenerateInclude: generatorConfigOptions.isGenerateInclude === 'true',
+    useDecimalLib: generatorConfigOptions.useDecimalLib === 'true',
   };
 }


### PR DESCRIPTION
Please see the [contributing guidelines](https://github.com/omar-dulaimi/prisma-zod-generator/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

I have [a side project](https://github.com/BooleT37/finances-t3) that since recently uses Decimal type for some Prisma table columns. I also uses zod types for requests validation, auto-generated by your library ([example](https://github.com/BooleT37/finances-t3/blob/main/src/server/api/routers/expenseRouter.ts#L17)). The decimal fields are converted to `Decimal` class [automatically](https://github.com/BooleT37/finances-t3/blob/10fc9334f927f5e41acfda1dad1ae6ee5338f759/src/server/api/trpc.ts#L73) by superjson, so that I don't have to do any extra convertations on server side and can pass them straight to Prisma. But unfortunately, my validations now fail since prisma-zod-generator treats all decimal fields as numbers. This PR aims to fix that.

This is a continuation of https://github.com/omar-dulaimi/prisma-zod-generator/pull/12. You said that "in the future decimal.js support may get added" so I decided to do it myself, since I need it anyway to unblock my project.

Since simply replacing the `z.number()` with `z.instanceof(Decimal)` would break backward compatibility, I opted out to introduce a new generator option for it, that is disabled by default. I don't think that this behaviour can be enabled by default even if we do a major version bump, since it is 

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.
