### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Prisma Zod Generator
 
 [![npm version](https://badge.fury.io/js/prisma-zod-generator.svg)](https://badge.fury.io/js/prisma-zod-generator)
+[![Network Dependents](https://dependents.info/omar-dulaimi/prisma-zod-generator/badge?label=users)](https://dependents.info/omar-dulaimi/prisma-zod-generator)
 [![npm downloads](https://img.shields.io/npm/dt/prisma-zod-generator.svg)](https://www.npmjs.com/package/prisma-zod-generator)
 [![CI/CD Pipeline](https://github.com/omar-dulaimi/prisma-zod-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/omar-dulaimi/prisma-zod-generator/actions)
 [![License: MIT](https://img.shields.io/npm/l/prisma-zod-generator.svg)](LICENSE)


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="691" height="147" alt="image" src="https://github.com/user-attachments/assets/85548766-f5d3-4dc2-af20-61c591b64869" />

I have not included the full user's image yet to keep the readme minimal.

Please feel free to close the PR if you don't want to have this!