### PR TITLE
fix: resolve output directory duplication when path ends with 'schemas'

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -64,8 +64,25 @@ export default class Transformer {
       prismaClientCustomPath !== '@prisma/client';
   }
 
+  /**
+   * Determines the schemas directory path based on the output path.
+   * If the output path already ends with 'schemas', use it directly.
+   * Otherwise, append 'schemas' to the output path.
+   */
+  private static getSchemasPath(): string {
+    const normalizedOutputPath = path.normalize(this.outputPath);
+    const pathSegments = normalizedOutputPath.split(path.sep);
+    const lastSegment = pathSegments[pathSegments.length - 1];
+    
+    if (lastSegment === 'schemas') {
+      return this.outputPath;
+    }
+    
+    return path.join(this.outputPath, 'schemas');
+  }
+
   static async generateIndex() {
-    const indexPath = path.join(Transformer.outputPath, 'schemas/index.ts');
+    const indexPath = path.join(Transformer.getSchemasPath(), 'index.ts');
     await writeIndexFile(indexPath);
   }
 
@@ -74,7 +91,7 @@ export default class Transformer {
       const { name, values } = enumType;
 
       await writeFileSafely(
-        path.join(Transformer.outputPath, `schemas/enums/${name}.schema.ts`),
+        path.join(Transformer.getSchemasPath(), `enums/${name}.schema.ts`),
         `${this.generateImportZodStatement()}\n${this.generateExportSchemaStatement(
           `${name}`,
           `z.enum(${JSON.stringify(values)})`,
@@ -98,8 +115,8 @@ export default class Transformer {
 
     await writeFileSafely(
       path.join(
-        Transformer.outputPath,
-        `schemas/objects/${objectSchemaName}.schema.ts`,
+        Transformer.getSchemasPath(),
+        `objects/${objectSchemaName}.schema.ts`,
       ),
       objectSchema,
     );
@@ -370,9 +387,9 @@ export default class Transformer {
     if (Transformer.isCustomPrismaClientOutputPath) {
       /**
        * If a custom location was designated for the prisma client, we need to figure out the
-       * relative path from {outputPath}/schemas/objects to {prismaClientCustomPath}
+       * relative path from {schemas path}/objects to {prismaClientCustomPath}
        */
-      const fromPath = path.join(Transformer.outputPath, 'schemas', 'objects');
+      const fromPath = path.join(Transformer.getSchemasPath(), 'objects');
       const toPath = Transformer.prismaClientOutputPath as string;
       const relativePathFromOutputToPrismaClient = path
         .relative(fromPath, toPath)
@@ -529,7 +546,7 @@ export default class Transformer {
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${findUnique}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${findUnique}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -549,7 +566,7 @@ export default class Transformer {
           `import { ${modelName}ScalarFieldEnumSchema } from './enums/${modelName}ScalarFieldEnum.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${findFirst}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${findFirst}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -569,7 +586,7 @@ export default class Transformer {
           `import { ${modelName}ScalarFieldEnumSchema } from './enums/${modelName}ScalarFieldEnum.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${findMany}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${findMany}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -587,7 +604,7 @@ export default class Transformer {
           `import { ${modelName}UncheckedCreateInputObjectSchema } from './objects/${modelName}UncheckedCreateInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${createOne}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${createOne}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -602,7 +619,7 @@ export default class Transformer {
           `import { ${modelName}CreateManyInputObjectSchema } from './objects/${modelName}CreateManyInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${createMany}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${createMany}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -624,7 +641,7 @@ export default class Transformer {
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${deleteOne}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${deleteOne}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -639,7 +656,7 @@ export default class Transformer {
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${deleteMany}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${deleteMany}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -658,7 +675,7 @@ export default class Transformer {
           `import { ${modelName}WhereUniqueInputObjectSchema } from './objects/${modelName}WhereUniqueInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${updateOne}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${updateOne}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -674,7 +691,7 @@ export default class Transformer {
           `import { ${modelName}WhereInputObjectSchema } from './objects/${modelName}WhereInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${updateMany}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${updateMany}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -695,7 +712,7 @@ export default class Transformer {
           `import { ${modelName}UncheckedUpdateInputObjectSchema } from './objects/${modelName}UncheckedUpdateInput.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${upsertOne}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${upsertOne}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -754,7 +771,7 @@ export default class Transformer {
         }
 
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${aggregate}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${aggregate}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(
@@ -774,7 +791,7 @@ export default class Transformer {
           `import { ${modelName}ScalarFieldEnumSchema } from './enums/${modelName}ScalarFieldEnum.schema'`,
         ];
         await writeFileSafely(
-          path.join(Transformer.outputPath, `schemas/${groupBy}.schema.ts`),
+          path.join(Transformer.getSchemasPath(), `${groupBy}.schema.ts`),
           `${this.generateImportStatements(
             imports,
           )}${this.generateExportSchemaStatement(

--- a/tests/issue-118-output-directory.test.ts
+++ b/tests/issue-118-output-directory.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+describe('Issue #118: Output Directory Structure', () => {
+  const testOutputDir = path.join(__dirname, '..', 'test-output-issue-118');
+  const schemasSubdir = path.join(testOutputDir, 'schemas');
+  const tempSchemaPath = path.join(__dirname, '..', 'temp-schema-118.prisma');
+
+  beforeAll(async () => {
+    // Clean up any existing test output
+    try {
+      await fs.rm(testOutputDir, { recursive: true, force: true });
+    } catch (error) {
+      // Directory might not exist, ignore
+    }
+
+    // Create a temporary schema file for testing with output pointing to a "schemas" subdirectory
+    const testSchema = `
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./test.db"
+}
+
+generator zod {
+  provider = "node ./lib/generator.js"
+  output   = "${schemasSubdir}"
+}
+
+model TestUser {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+  posts TestPost[]
+}
+
+model TestPost {
+  id      Int       @id @default(autoincrement())
+  title   String
+  content String?
+  author  TestUser? @relation(fields: [authorId], references: [id])
+  authorId Int?
+}
+`;
+
+    await fs.writeFile(tempSchemaPath, testSchema);
+  });
+
+  afterAll(async () => {
+    // Clean up test files
+    try {
+      await fs.rm(testOutputDir, { recursive: true, force: true });
+      await fs.rm(tempSchemaPath, { force: true });
+    } catch (error) {
+      // Files might not exist, ignore
+    }
+  });
+
+  it('should generate schemas directly in the specified output directory, not in a nested schemas/ folder', async () => {
+    // Build the generator first
+    await execAsync('tsc', { cwd: path.join(__dirname, '..') });
+
+    // Run prisma generate with our test schema
+    await execAsync(`npx prisma generate --schema="${tempSchemaPath}"`, {
+      cwd: path.join(__dirname, '..')
+    });
+
+    // Verify the directory structure
+    const schemasExists = await fs.access(schemasSubdir).then(() => true).catch(() => false);
+    expect(schemasExists, 'Schemas directory should exist').toBe(true);
+
+    // The problematic behavior: schemas should NOT be nested in another schemas/ folder
+    const nestedSchemasPath = path.join(schemasSubdir, 'schemas');
+    const nestedSchemasExists = await fs.access(nestedSchemasPath).then(() => true).catch(() => false);
+    expect(nestedSchemasExists, 'Should NOT create nested schemas/schemas/ directory').toBe(false);
+
+    // Verify schemas are directly in the specified output directory
+    const expectedFiles = [
+      'index.ts',
+      'enums',
+      'objects'
+    ];
+
+    for (const expectedItem of expectedFiles) {
+      const itemPath = path.join(schemasSubdir, expectedItem);
+      const exists = await fs.access(itemPath).then(() => true).catch(() => false);
+      expect(exists, `${expectedItem} should exist directly in the output directory`).toBe(true);
+    }
+
+    // Verify some actual schema files exist in the expected locations
+    const enumsDir = path.join(schemasSubdir, 'enums');
+    const objectsDir = path.join(schemasSubdir, 'objects');
+
+    const enumsExists = await fs.access(enumsDir).then(() => true).catch(() => false);
+    const objectsExists = await fs.access(objectsDir).then(() => true).catch(() => false);
+    
+    expect(enumsExists, 'enums directory should exist').toBe(true);
+    expect(objectsExists, 'objects directory should exist').toBe(true);
+
+    // Check for some generated schema files
+    const sampleFiles = [
+      path.join(schemasSubdir, 'findManyTestUser.schema.ts'),
+      path.join(schemasSubdir, 'createOneTestPost.schema.ts')
+    ];
+
+    for (const sampleFile of sampleFiles) {
+      const exists = await fs.access(sampleFile).then(() => true).catch(() => false);
+      expect(exists, `${path.basename(sampleFile)} should exist in the output directory`).toBe(true);
+    }
+  });
+
+  it('should work correctly when output directory does not end with "schemas"', async () => {
+    const regularOutputDir = path.join(testOutputDir, 'regular-output');
+    
+    const testSchema = `
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./test.db"
+}
+
+generator zod {
+  provider = "node ./lib/generator.js"
+  output   = "${regularOutputDir}"
+}
+
+model TestUser {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+}
+`;
+
+    const tempSchemaPath2 = path.join(__dirname, '..', 'temp-schema-118-regular.prisma');
+    await fs.writeFile(tempSchemaPath2, testSchema);
+
+    try {
+      // Run prisma generate with regular output directory
+      await execAsync(`npx prisma generate --schema="${tempSchemaPath2}"`, {
+        cwd: path.join(__dirname, '..')
+      });
+
+      // For regular output (not ending with 'schemas'), it should create a schemas subdirectory
+      const schemasPath = path.join(regularOutputDir, 'schemas');
+      const schemasExists = await fs.access(schemasPath).then(() => true).catch(() => false);
+      expect(schemasExists, 'schemas subdirectory should exist when output does not end with "schemas"').toBe(true);
+
+      // Verify files are in the schemas subdirectory
+      const indexFile = path.join(schemasPath, 'index.ts');
+      const indexExists = await fs.access(indexFile).then(() => true).catch(() => false);
+      expect(indexExists, 'index.ts should exist in schemas subdirectory').toBe(true);
+
+    } finally {
+      await fs.rm(tempSchemaPath2, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes issue #118 where setting `output = "../generated/schemas"` creates nested `schemas/schemas/` directory
- Adds `getSchemasPath()` method to detect when output path already ends with 'schemas'
- Maintains backward compatibility for output paths that don't end with 'schemas'
- Includes comprehensive test coverage for both problematic and working scenarios

## Test plan

- [x] Added regression test `tests/issue-118-output-directory.test.ts`
- [x] Test verifies schemas are generated directly in specified directory when path ends with 'schemas'
- [x] Test verifies backward compatibility when path doesn't end with 'schemas'  
- [x] All existing tests pass
- [x] Manual testing confirms fix works as expected