### PR TITLE
fix: correct skipDuplicates support for database providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-zod-generator",
-  "version": "0.8.15",
+  "version": "1.0.5",
   "description": "Prisma 2+ generator to emit Zod schemas from your Prisma schema",
   "repository": "https://github.com/omar-dulaimi/prisma-zod-generator",
   "bin": {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -690,10 +690,10 @@ export default class Transformer {
           )}${this.generateExportSchemaStatement(
             `${modelName}CreateMany`,
             `z.object({ data: z.union([ ${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema) ]), ${
-              Transformer.provider === 'mongodb' ||
-              Transformer.provider === 'sqlserver'
-                ? ''
-                : 'skipDuplicates: z.boolean().optional()'
+              Transformer.provider === 'postgresql' ||
+              Transformer.provider === 'cockroachdb'
+                ? 'skipDuplicates: z.boolean().optional()'
+                : ''
             } })`,
           )}`,
         );


### PR DESCRIPTION
## Summary
- Fixed skipDuplicates property inclusion in createMany schemas to only support PostgreSQL and CockroachDB providers
- Excluded skipDuplicates for SQLite, MongoDB, and SQL Server as they don't support this Prisma feature
- Updated package.json version to correct 1.0.5

## Problem
The generator was incorrectly including the `skipDuplicates` property in createMany schemas for SQLite, causing TypeScript compilation errors since SQLite doesn't support this feature in Prisma's createMany operation.

## Solution
Changed the provider condition from excluding specific providers to only including the providers that actually support skipDuplicates (PostgreSQL and CockroachDB).

## Test plan
- [x] Generated schemas for SQLite - confirms skipDuplicates is excluded
- [x] Generated schemas for PostgreSQL - confirms skipDuplicates is included
- [x] Verified fix resolves TypeScript errors in dependent projects

## Files changed
- `src/transformer.ts` - Updated provider condition logic
- `package.json` - Fixed version number to match releases