### PR TITLE
feat: add support for new prisma-client generator

### DIFF
--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -45,7 +45,10 @@ export async function generate(options: GeneratorOptions) {
       previewFeatures: prismaClientGeneratorConfig?.previewFeatures,
     });
 
+
     checkForCustomPrismaClientOutputPath(prismaClientGeneratorConfig);
+    setPrismaClientProvider(prismaClientGeneratorConfig);
+    setPrismaClientConfig(prismaClientGeneratorConfig);
 
     const modelOperations = prismaClientDmmf.mappings.modelOperations;
     const inputObjectTypes = prismaClientDmmf.schema.inputObjectTypes.prisma;
@@ -144,6 +147,24 @@ function checkForCustomPrismaClientOutputPath(
     Transformer.setPrismaClientOutputPath(
       prismaClientGeneratorConfig.output?.value as string,
     );
+  }
+}
+
+function setPrismaClientProvider(
+  prismaClientGeneratorConfig: GeneratorConfig | undefined,
+) {
+  if (prismaClientGeneratorConfig?.provider) {
+    Transformer.setPrismaClientProvider(
+      parseEnvValue(prismaClientGeneratorConfig.provider),
+    );
+  }
+}
+
+function setPrismaClientConfig(
+  prismaClientGeneratorConfig: GeneratorConfig | undefined,
+) {
+  if (prismaClientGeneratorConfig?.config) {
+    Transformer.setPrismaClientConfig(prismaClientGeneratorConfig.config);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for the new `prisma-client` generator introduced in Prisma 6.12.0 as a preview feature. The implementation maintains full backward compatibility while enabling seamless usage of the new generator.

### Key Changes

- **Enhanced Generator Detection**: Automatically detects new `prisma-client` generator using provider name and config fields
- **Smart Import Path Resolution**: Applies `/client` suffix to import paths when using new generator with custom output directories
- **Multi-Provider Support**: Works across all database providers (PostgreSQL, MySQL, MongoDB, SQLite, SQL Server)
- **Backward Compatibility**: Zero breaking changes for existing `prisma-client-js` users

### Technical Implementation

The solution leverages the generator configuration differences to detect the new generator:
- New generator has additional config fields like `moduleFormat` and `runtime`
- Custom output paths require `/client` suffix for type imports
- Fallback detection using provider name for edge cases

### Testing

- ✅ All existing tests pass (21/21 basic tests)
- ✅ Multi-provider integration tests pass (334/334 tests)
- ✅ Comprehensive testing with both old and new generators
- ✅ Verified correct import paths across all scenarios

### Fixes

Closes #127

### Breaking Changes

None - this is a fully backward compatible enhancement.

### Migration Guide

No migration required. Users can switch to the new generator in their `schema.prisma`:

```prisma
// Old (still supported)
generator client {
  provider = "prisma-client-js"
}

// New (now supported)
generator client {
  provider = "prisma-client"
  output   = "./src/generated/client"
}
```

The Zod generator will automatically detect and handle both configurations correctly.