### PR TITLE
fix: inline object schemas, add dual exports, and correct aggregate input bindings

### DIFF
--- a/src/helpers/whereUniqueInput-helpers.ts
+++ b/src/helpers/whereUniqueInput-helpers.ts
@@ -8,12 +8,20 @@ export function changeOptionalToRequiredFields(
       item.name.includes('WhereUniqueInput') &&
       (item.constraints.fields?.length ?? 0) > 0
     ) {
-      (item as DMMF.InputType & { fields: DMMF.SchemaArg[] }).fields = item.fields.map((subItem) => {
-        if (item.constraints.fields?.includes(subItem.name)) {
+      const uniqueFields = item.constraints.fields!;
+      // First, mark unique fields as required
+      let updatedFields = item.fields.map((subItem) => {
+        if (uniqueFields.includes(subItem.name)) {
           return { ...subItem, isRequired: true };
         }
         return subItem;
       });
+
+      // Then, restrict WhereUniqueInput to ONLY the unique identifier fields
+      // This avoids leaking WhereInput-style fields (AND/OR/NOT, filters) into WhereUniqueInput
+      updatedFields = updatedFields.filter((subItem) => uniqueFields.includes(subItem.name));
+
+      (item as DMMF.InputType & { fields: DMMF.SchemaArg[] }).fields = updatedFields;
     }
     return item;
   });

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -1,26 +1,26 @@
 import {
-  DMMF,
-  EnvValue,
-  GeneratorConfig,
-  GeneratorOptions,
+    DMMF,
+    EnvValue,
+    GeneratorConfig,
+    GeneratorOptions,
 } from '@prisma/generator-helper';
 import { getDMMF, parseEnvValue } from '@prisma/internals';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { processConfiguration } from './config/defaults';
 import {
-  generatorOptionsToConfigOverrides,
-  getLegacyMigrationSuggestions,
-  isLegacyUsage,
-  parseGeneratorOptions,
-  validateGeneratorOptions
+    generatorOptionsToConfigOverrides,
+    getLegacyMigrationSuggestions,
+    isLegacyUsage,
+    parseGeneratorOptions,
+    validateGeneratorOptions
 } from './config/generator-options';
 import { GeneratorConfig as CustomGeneratorConfig, parseConfiguration } from './config/parser';
 import {
-  addMissingInputObjectTypes,
-  hideInputObjectTypesAndRelatedFields,
-  resolveAddMissingInputObjectTypeOptions,
-  resolveModelsComments,
+    addMissingInputObjectTypes,
+    hideInputObjectTypesAndRelatedFields,
+    resolveAddMissingInputObjectTypeOptions,
+    resolveModelsComments,
 } from './helpers';
 import { resolveAggregateOperationSupport } from './helpers/aggregate-helpers';
 import Transformer from './transformer';
@@ -397,7 +397,7 @@ async function generateObjectSchemas(inputObjectTypes: DMMF.InputType[], models:
       if (modelName) {
         // Apply field filtering using the transformer's filtering logic
         // Cast to the expected type to handle ReadonlyDeep wrapper
-        filteredFields = Transformer.filterFields(originalFields as any, modelName, variant, models);
+  filteredFields = Transformer.filterFields(originalFields as any, modelName, variant, models, name);
       }
     }
     


### PR DESCRIPTION
This PR includes a set of fixes to the object schema generator:\n\n- Inline object schema exports to match CRUD style (no intermediate const).\n- Dual exports for object schemas: typed Prisma version and pure Zod version.\n- Bind aggregate input types to the correct Prisma `*InputType` variants (e.g., `PlanetCountAggregateInputType`).\n- Restrict `WhereUniqueInput` to only unique identifier fields and mark them as required.\n\nNotes:\n- Dual export flags still respected (`exportTypedSchemas`, `exportZodSchemas`).\n- Naming remains backward-compatible for existing imports (`<Name>ObjectSchema`).\n\nImpact: patch release (fix).