### PR TITLE
[fix] enums not importing to schema files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build": "tsc",
     "exec": "npm run gen-example && npm run test:features:filtering -- -t \"should handle combinations of model, operation, and field filtering\"",
-    "gen-example": "tsc && npx prisma generate > full-log.txt 2>&1",
-    "gen-example:debug": "tsc && DEBUG_PRISMA_ZOD=1 npx prisma generate > full-log.txt 2>&1",
+    "gen-example": "tsc && npx prisma generate",
+    "gen-example:debug": "tsc && DEBUG_PRISMA_ZOD=1 npx prisma generate",
     "check-uncommitted": "git diff-index --quiet HEAD --",
     "package:publish": "npm update && npm run check-uncommitted && ./package.sh && cd package && npm publish",
     "test": "vitest | tee generation-output.txt",

--- a/src/variants/generator.ts
+++ b/src/variants/generator.ts
@@ -4,14 +4,13 @@
  */
 
 import { DMMF } from '@prisma/generator-helper';
-import { VariantType, VariantGenerationResult, ModelVariantCollection } from '../types/variants';
-import { VariantConfigurationManager } from './config';
-import { VariantConfig } from '../types/variants';
-import { VariantNamingSystem, NamingResult } from '../utils/naming';
-import { PrismaTypeMapper } from '../generators/model';
-import { writeFileSafely } from '../utils/writeFileSafely';
-import { formatFile } from '../utils/formatFile';
 import { promises as fs } from 'fs';
+import { PrismaTypeMapper } from '../generators/model';
+import { ModelVariantCollection, VariantConfig, VariantGenerationResult, VariantType } from '../types/variants';
+import { formatFile } from '../utils/formatFile';
+import { NamingResult, VariantNamingSystem } from '../utils/naming';
+import { writeFileSafely } from '../utils/writeFileSafely';
+import { VariantConfigurationManager } from './config';
 
 /**
  * File generation context
@@ -367,10 +366,18 @@ export class VariantFileGenerationCoordinator {
     }
     if (usedEnums.size > 0) {
       const enumImportLine = `import { ${Array.from(usedEnums).join(', ')} } from '@prisma/client';`;
-      const hasImport = new RegExp(
-        `import\\s*\\{[^}]*\\b${Array.from(usedEnums).join('\\b|\\b')}\\b[^}]*\\}\\s*from\\s*['"]@prisma/client['"];?`
-      ).test(customizedContent);
-      if (!hasImport) {
+      // Check if an existing import from @prisma/client already includes all used enums
+      const importRegex = /import\s*\{([^}]*)\}\s*from\s*['"]@prisma\/client['"];?/;
+      const importMatch = customizedContent.match(importRegex);
+      let hasAllEnumImports = false;
+      if (importMatch) {
+        const importedEnums = importMatch[1]
+          .split(',')
+          .map(e => e.trim())
+          .filter(e => e.length > 0);
+        hasAllEnumImports = Array.from(usedEnums).every(enumName => importedEnums.includes(enumName));
+      }
+      if (!hasAllEnumImports) {
         // Insert after zod import
         customizedContent = customizedContent.replace(
           /(import\s*\{\s*z\s*\}\s*from\s*['"]zod['"]\s*;?\s*)/,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    watch: false,
     globals: true,
     environment: 'node',
     include: ['tests/**/*.{test,spec}.ts'],


### PR DESCRIPTION
Enums are not getting imported into generated schema files. This PR fixes this issue by detecting if enum field is being used in schema and accessing enum storages to import enums chema from prisma/client

i know that enum schemas are gettings generated too, but i think it's better to import them from prisma/client directly to be on more stable side 

how to check:

- generate prisma schema on master branch

- look into schemas/variants/pure/User.pure.ts

enum Role won't be imported automatically 

