### PR TITLE
fix(docs): repair Docusaurus SSG and broken links on homepage

### DIFF
--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -4,8 +4,8 @@ title: Contributing
 ---
 
 > ❤️ **Sustainability Matters** – Sponsorship directly funds maintenance, regression fixes, and new feature velocity.
-<div style="margin: .75rem 0 1.25rem;">
-	<a href="https://github.com/sponsors/omar-dulaimi" class="button button--primary">Sponsor on GitHub</a>
+<div style={{ margin: '.75rem 0 1.25rem' }}>
+	<a href="https://github.com/sponsors/omar-dulaimi" className="button button--primary">Sponsor on GitHub</a>
 </div>
 
 Tests use Vitest; comprehensive generation tests cover multi-provider & feature flags.
@@ -35,4 +35,4 @@ Sponsorship accelerates:
 - Advanced JSON / Bytes features & recipes
 - Documentation polish & DX tooling
 
-<a href="https://github.com/sponsors/omar-dulaimi" class="button button--secondary button--sm">Become a Sponsor</a>
+<a href="https://github.com/sponsors/omar-dulaimi" className="button button--secondary button--sm">Become a Sponsor</a>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -52,11 +52,11 @@ const Home: React.FC = () => {
               Generate type-safe validation & inference schemas directly from your Prisma schema. Dual exports, pure models, modes, smart emission & filtering — tuned for DX and performance.
             </p>
             <div className="pz-hero-buttons" style={{marginTop: '1.6rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap'}}>
-              <Link className="pz-btn pz-btn-primary" to="/prisma-zod-generator/docs/intro/quick-start">
+              <Link className="pz-btn pz-btn-primary" to="/docs/next/intro/quick-start">
                 <span className="pz-btn-icon" aria-hidden="true">🚀</span>
                 <span>Get Started</span>
               </Link>
-              <Link className="pz-btn pz-btn-secondary" to="/prisma-zod-generator/docs/config/precedence">
+              <Link className="pz-btn pz-btn-secondary" to="/docs/next/config/precedence">
                 <span className="pz-btn-icon" aria-hidden="true">⚙️</span>
                 <span>Config Deep Dive</span>
               </Link>
@@ -132,7 +132,7 @@ const Home: React.FC = () => {
             <div style={{border:'1px solid var(--ifm-color-emphasis-300)', borderRadius:16, padding:'1.25rem 1.2rem', background:'linear-gradient(135deg,rgba(34,197,94,.10),rgba(56,189,248,.08))'}}>
               <h3 style={{marginTop:0, fontSize:'1rem'}}>DX Highlights</h3>
               <p style={{fontSize:'.78rem', margin:'0 0 .6rem'}}>Dual exports, lean pure models, heuristic emission, single-file bundling, depth-aware JSON.</p>
-              <Link className="button button--sm button--secondary" to="/prisma-zod-generator/docs/usage-patterns">See Patterns</Link>
+              <Link className="button button--sm button--secondary" to="/docs/next/usage-patterns">See Patterns</Link>
             </div>
           </div>
         </section>
@@ -155,9 +155,9 @@ const Home: React.FC = () => {
           <h2 style={{fontSize: '1.95rem'}}>Why It Stays Maintainable</h2>
           <p style={{maxWidth: 860}}>Focused logs, strict types, test matrix across providers, and opt-in advanced features keep complexity under control. Tailor output granularity without forked pipelines.</p>
           <div style={{display: 'flex', gap: '1rem', flexWrap: 'wrap', marginTop: '1.5rem'}}>
-            <Link className="button button--primary" to="/prisma-zod-generator/docs/usage-patterns">Usage Patterns</Link>
-            <Link className="button button--secondary" to="/prisma-zod-generator/docs/reference/faq">FAQ</Link>
-            <Link className="button button--outline" to="/prisma-zod-generator/docs/reference/logging-debug">Debug Logging</Link>
+            <Link className="button button--primary" to="/docs/next/usage-patterns">Usage Patterns</Link>
+            <Link className="button button--secondary" to="/docs/next/reference/faq">FAQ</Link>
+            <Link className="button button--outline" to="/docs/next/reference/logging-debug">Debug Logging</Link>
           </div>
         </section>
         <section style={{marginTop: '5rem'}}>


### PR DESCRIPTION
## Summary
Fix Docusaurus build failure on CI by correcting invalid MDX/JSX in `contributing.md` and aligning homepage internal links with current docs routing.

## What changed
- docs(contributing):
  - Replace HTML `class` with `className`.
  - Convert string `style="..."` to React style object `style={{ ... }}`.
- homepage:
  - Update internal links to use `/docs/next/...` and avoid hard-coded baseUrl prefix.

## Why
- CI failed with: "The `style` prop expects a mapping from style properties to values, not a string" during SSG for `/docs/next/contributing`.
- After fixing, Docusaurus broken links check flagged homepage links that included `/prisma-zod-generator` baseUrl prefix. Adjusted to versioned paths.

## Verification
- Ran `npm run docs:build` locally; build now succeeds.
- Docusaurus version: 3.8.1
- Node: v22.17.1 (local)

## Notes
- Optionally update npm scripts to "docusaurus build website" to remove cd warning; left as-is for minimal diff.

