### PR TITLE
fix(prisma-import): target Prisma client entry in generated Zod imports

### DIFF
--- a/src/utils/singleFileAggregator.ts
+++ b/src/utils/singleFileAggregator.ts
@@ -14,7 +14,7 @@ let prismaImportBase = '@prisma/client';
 let needsJsonHelpers = false; // whether to inject json helpers block
 
 export function setSingleFilePrismaImportPath(importPath: string) {
-  prismaImportBase = importPath || '@prisma/client';
+  prismaImportBase = (importPath || '@prisma/client').replace(/\\/g, '/');
 }
 
 export function initSingleFile(bundleFullPath: string) {


### PR DESCRIPTION
## Summary
Fix Prisma Client import path in generated Zod schemas when using the new `prisma-client` generator with a custom output. Imports now target the public `client` entry (e.g. `../../prisma/client`) instead of the directory root.

## Context
With Prisma v6 and the new `generator client { provider = "prisma-client" ... }`, the public entrypoint is the generated `client` module under the configured output directory. Previously, this generator imported from the output directory root (e.g., `../../prisma`), which lacks an index and caused `TS2307: Cannot find module` in generated schemas.

## Changes
- transformer: compute Prisma import path relative to target dir and append `/client` when provider is `prisma-client`.
- single-file mode: ensure the inlined bundle imports `Prisma` from the `/client` entry when custom output is configured.
- minor fix: repaired foreign key field helper to restore a clean build.

## Verification
- Local generation succeeds without import errors.
- Feature suites (Vitest) pass:
  - results (tests/result-schemas.test.ts)
  - field exclusions (tests/field-exclusion.test.ts)
  - @zod comments (tests/zod-comments.test.ts)
- Smoke: `npm run gen-example` completes and generated files import from `.../prisma/client`.

## Compatibility
- No breaking changes expected. Behavior aligns generated imports with Prisma v6 `prisma-client` generator.
- Bytes mapping and public API unaffected.

## Notes
- In single-file mode, the bundle header now also imports from the `client` entry where applicable.
