### PR TITLE
feat(zod-import-target): add zodImportTarget config and update imports across generator

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -16,6 +16,7 @@ Quick navigation:
 - [Variants](#variants)
 - [Per‑model overrides](#models)
 - [Single-file mode specifics](#single-file-mode)
+- [Zod import target](#zod-import-target)
 - [Field exclusion precedence](#field-exclusion-logic-summary)
 - [Patterns & examples](#recommended-config-patterns)
 - [Troubleshooting / FAQ](#troubleshooting)
@@ -177,6 +178,22 @@ Additional keys:
 Behavioral differences:
 - Index barrels ignored (content is concatenated).
 - Pure models can be inlined exclusively if variants disabled (optimization).
+
+## Zod import target
+
+Control how the generator imports Zod to support consumers on Zod v3 or Zod v4.
+
+| Option | Type | Default | Effect |
+|--------|------|---------|--------|
+| `zodImportTarget` | `"auto" | "v3" | "v4"` | `"auto"` | Chooses the import statement emitted in generated files. |
+
+Mapping:
+- `auto` (and `v3`): `import { z } from 'zod'` (works with Zod v3 and v4)
+- `v4`: `import * as z from 'zod/v4'`
+
+Notes:
+- The package now declares a peerDependency on Zod: `>=3.25.0 <5`. Install your preferred Zod version in your app.
+- Single-file bundles hoist a single Zod import at the top using the same strategy.
 
 ## Field Exclusion Logic Summary
 Order of application:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:features:pure": "vitest run tests/pure-models.test.ts",
     "test:features:variants": "vitest run tests/schema-variants.test.ts",
     "test:features:results": "vitest run tests/result-schemas.test.ts",
+    "test:features:zodImports": "vitest run tests/zod-imports.test.ts",
     "test:features:circular-dependency-exclusion": "vitest run tests/circular-dependency-exclusion.test.ts --reporter=default",
     "test:features:naming-customization": "vitest run tests/naming-customization.test.ts --reporter=default",
     "test:features:prisma-client-preview": "vitest run tests/prisma-client-preview-options.test.ts",
@@ -102,8 +103,10 @@
     "ajv-formats": "^3.0.1",
     "node-fetch": "^3.3.2",
     "prettier": "^3.6.2",
-    "tslib": "^2.8.1",
-    "zod": "^4.0.17"
+    "tslib": "^2.8.1"
+  },
+  "peerDependencies": {
+    "zod": ">=3.25.0 <5"
   },
   "devDependencies": {
     "@docusaurus/core": "^3.8.1",
@@ -131,7 +134,8 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "zod": "^4.0.17"
   },
   "resolutions": {
     "postcss": "^8.4.38"

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,118 +1,44 @@
-# Recipes: common configuration presets and patterns
+# Recipes overview
 
-This folder collects community-requested “recipes” as drop-in JSON configs and small code/prisma examples. Pick what matches your use-case, copy the JSON into your project as `zod-generator.config.json` (or any name you reference), and point your Prisma generator block at it.
+This folder contains “recipes”: small, focused configuration presets you can drop into your project. A recipe is a starting point for a common setup; details and trade‑offs live in each recipe’s own README.
 
-Important: The Prisma generator block takes precedence over the JSON for simple options like file layout. If your schema.prisma sets `useMultipleFiles`, `singleFileName`, or `placeSingleFileAtRoot`, it will override the recipe JSON. Keep them in sync to avoid surprises.
+What a recipe includes
+- A `zod-generator.config.json` you can copy as‑is.
+- A short `README.md` explaining when/why to use it.
+- Optionally, a `schema.prisma` snippet to help you wire it up.
 
+How to use a recipe
+1) Copy the recipe’s `zod-generator.config.json` into your repo (rename if you like).
+2) Reference it from your Prisma generator block and set your desired output path.
+3) Run Prisma generate.
+
+Generator block example
 ```prisma
 generator zod {
   provider = "prisma-zod-generator"
   output   = "./prisma/generated"
-  // point to the recipe you chose (copy into your app repo)
+  // path is relative to schema.prisma
   config   = "./zod-generator.config.json"
 }
 ```
 
-Recommended generator blocks
+Important precedence note
+- The Prisma generator block takes precedence over JSON for simple file‑layout options.
+- If `schema.prisma` sets `useMultipleFiles`, `singleFileName`, or `placeSingleFileAtRoot`, it will override the JSON. Keep them aligned to avoid surprises.
 
-- Single-file output
+Discover recipes
+- Browse the folders under `recipes/`. Each folder has its own README with specifics and trade‑offs.
 
-```prisma
-generator zod {
-  provider              = "prisma-zod-generator"
-  output                = "./prisma/generated"
-  // Keep these in the generator block so they can't be accidentally overridden
-  useMultipleFiles      = false
-  singleFileName        = "schemas.ts" // optional; default is schemas.ts
-  placeSingleFileAtRoot = true         // optional; default is true
-  config                = "./zod-generator.config.json"
-}
-```
+Validation
+- The test suite validates every `.json` in `recipes/` against the config schema to catch drift early.
 
-- Multi-file output (models-only and most others)
+Contributing a new recipe
+- Add `recipes/<your-name>/` with:
+  - `zod-generator.config.json` (no comments)
+  - `README.md` describing the use case
+  - Optional `schema.prisma` snippet
+- Run tests to validate your JSON before opening a PR.
 
-```prisma
-generator zod {
-  provider         = "prisma-zod-generator"
-  output           = "./prisma/generated"
-  useMultipleFiles = true
-  config           = "./zod-generator.config.json"
-}
-```
-
-Tip: If your generator block already sets `useMultipleFiles`, `singleFileName`, or `placeSingleFileAtRoot`, make sure those match the recipe to prevent unexpected extra files or a bundle when you wanted many files.
-
-Notes on logging: If there’s a mismatch, you’ll see a concise, tagged info line in the Prisma output. Enable `DEBUG_PRISMA_ZOD=1` for conflict details.
-
-Notes:
-- All recipe files are pure JSON (no comments). Adjust model names for your app. The output path is controlled by the Prisma generator block, not the JSON.
-- You can combine ideas across recipes. Options follow the precedence documented in the root README.
-- For single-file output, variant files are skipped internally; you don’t need to disable them.
-
-Per-recipe generator block snippets
-
-Ready-to-copy generator blocks now live inside each recipe folder under `recipes/<name>/schema.prisma`:
-
-- single-file/schema.prisma
-- models-only/schema.prisma
-- minimal-crud/schema.prisma
-- api-result-schemas/schema.prisma
-- trpc-optimized/schema.prisma
-- hide-fields/schema.prisma
-- granular-per-model/schema.prisma
-
-Foldered quick-starts
-
-Prefer a copy-paste starter? Each recipe now has a folder with:
-
-- zod-generator.config.json (ready to use)
-- schema.prisma (contains a matching generator block you can copy)
-- README.md (short how-to)
-
-Folders:
-
-- models-only/
-- single-file/
-- minimal-crud/
-- api-result-schemas/
-- trpc-optimized/
-- hide-fields/
-- granular-per-model/
-
-## Index
-
-- single-file/ — One physical file with everything (Issue #140)
-- models-only/ — Only pure model schemas (Issues #139, #43)
-- minimal-crud/ — Minimal mode: CRUD only (Issue #84)
-- api-result-schemas/ — Result/response schemas only (Issue #72)
-- hide-fields/ — Hide properties globally/per-model (Issue #75)
-- granular-per-model/ — Select operations per model, disable models (Issue #49)
-- trpc-optimized/ — Input/output focused for tRPC (Issues #49, #139)
-- pure-models-lean/ — Pure models only with lean docs + DateTime strategy options
-- schema-comments/schema.prisma — Rich @zod field validation (Issue #80)
-- derive-trpc-schemas/derive-trpc-schemas.ts — Derive request schemas via omit/extend (Issue #49)
-
-## How to use
-
-1) Copy a recipe JSON to your application repo as `zod-generator.config.json`.
-2) Update your Prisma `generator zod` block to set `config = "./zod-generator.config.json"`.
-3) Adjust the generator block `output` (path) and make sure `useMultipleFiles`/`singleFileName` match the recipe you chose.
-4) Run generation.
-
-## Create input strictness options
-
-Two config switches control how Create-like inputs handle exclusions:
-
-- strictCreateInputs (boolean, default: true)
-  - true: Create* inputs match Prisma exactly; exclusions do not apply to these inputs.
-  - false: Exclusions apply to Create* inputs as well.
-- preserveRequiredScalarsOnCreate (boolean, default: true)
-  - When strictCreateInputs is false, this keeps truly required scalar fields present in Create* inputs even if they are listed for exclusion.
-
-Tip: To fully hide fields (including required scalars) from Create* inputs, set:
-
-{ "strictCreateInputs": false, "preserveRequiredScalarsOnCreate": false }
-
-## Acknowledgements
-
-These recipes are distilled from community requests and discussions in issues: #140, #139, #84, #80, #75, #72, #49, #43.
+Troubleshooting
+- If file layout looks off, compare the generator block and JSON—generator block wins for layout.
+- You can enable verbose logs by setting `DEBUG_PRISMA_ZOD=1` during generation to surface conflicts.

--- a/recipes/zod-imports/README.md
+++ b/recipes/zod-imports/README.md
@@ -1,0 +1,18 @@
+# Zod import target recipes
+
+Choose how generated schemas import Zod using `zodImportTarget`.
+
+When to use
+- You need to pin Zod v4 style to reduce bundle size.
+- You want to keep default imports compatible with Zod v3 style.
+
+Options
+- auto (default) or v3: `import { z } from 'zod'`
+- v4: `import * as z from 'zod/v4'`
+
+Notes
+- Single-file bundles hoist a single Zod import accordingly.
+- This generator treats Zod as a peer dependency; install it in your app.
+
+See also
+- Docs: Recipes → Zod import targets

--- a/recipes/zod-imports/zod-generator.auto.json
+++ b/recipes/zod-imports/zod-generator.auto.json
@@ -1,0 +1,3 @@
+{
+  "zodImportTarget": "auto"
+}

--- a/recipes/zod-imports/zod-generator.v3.json
+++ b/recipes/zod-imports/zod-generator.v3.json
@@ -1,0 +1,3 @@
+{
+  "zodImportTarget": "v3"
+}

--- a/recipes/zod-imports/zod-generator.v4.json
+++ b/recipes/zod-imports/zod-generator.v4.json
@@ -1,0 +1,3 @@
+{
+  "zodImportTarget": "v4"
+}

--- a/src/config/parser.ts
+++ b/src/config/parser.ts
@@ -121,6 +121,14 @@ export interface GeneratorConfig {
   };
 
   /**
+   * Controls how Zod is imported in generated files.
+   * - auto (default): import from 'zod' (compatible with Zod v3 and v4)
+   * - v3: force import from 'zod'
+   * - v4: import from 'zod/v4'
+   */
+  zodImportTarget?: 'auto' | 'v3' | 'v4';
+
+  /**
    * Explicit emission controls. When provided, these booleans override heuristic
    * behaviors (minimal mode, pure-variant-only, etc.) for the respective groups.
    * Omitting a key preserves legacy behavior for that group.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -240,6 +240,14 @@ export const ConfigurationSchema: JSONSchema7 = {
         },
       },
     },
+
+    zodImportTarget: {
+      type: 'string',
+      enum: ['auto', 'v3', 'v4'],
+      default: 'auto',
+      description:
+        "How to import Zod in generated code: 'auto'|'v3' uses import { z } from 'zod'; 'v4' uses import * as z from 'zod/v4'",
+    },
   },
 
   definitions: {

--- a/src/generators/model.ts
+++ b/src/generators/model.ts
@@ -2129,7 +2129,13 @@ export class PrismaTypeMapper {
 
     // Zod import
     if (imports.includes('z')) {
-      lines.push("import { z } from 'zod';");
+      // Defer to Transformer import strategy to honor zodImportTarget
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const transformer = require('../transformer').default;
+      const importLine = transformer.prototype.generateImportZodStatement
+        ? transformer.prototype.generateImportZodStatement.call(transformer)
+        : "import { z } from 'zod';\n";
+      lines.push(importLine.trimEnd());
     }
 
     // Get naming configuration for proper import path generation
@@ -2153,7 +2159,7 @@ export class PrismaTypeMapper {
     );
     enumSchemaImports.forEach((imp) => {
       const enumBase = imp.replace(/Schema$/, '');
-      lines.push(`import { ${imp} } from '../schemas/enums/${enumBase}.schema';`);
+      lines.push(`import { ${imp} } from '../enums/${enumBase}.schema';`);
     });
 
     // Related model schema imports (exclude current schema + enums)

--- a/tests/zod-imports.test.ts
+++ b/tests/zod-imports.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  ConfigGenerator,
+  GENERATION_TIMEOUT,
+  PrismaSchemaGenerator,
+  TestEnvironment,
+} from './helpers';
+
+describe('Zod import target', () => {
+  it(
+    "emits 'zod/v4' import when zodImportTarget is v4 (single-file)",
+    async () => {
+      const env = await TestEnvironment.createTestEnv('zod-imports-v4-single-file');
+      try {
+        const config = {
+          ...ConfigGenerator.createBasicConfig(),
+          useMultipleFiles: false,
+          zodImportTarget: 'v4',
+        } as Partial<import('../src/config/parser').GeneratorConfig>;
+        const configPath = join(env.testDir, 'config.json');
+        writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+        const schema = PrismaSchemaGenerator.createBasicSchema({
+          outputPath: `${env.outputDir}/schemas`,
+          generatorOptions: { config: './config.json' },
+        });
+        writeFileSync(env.schemaPath, schema);
+        await env.runGeneration();
+
+        const bundlePath = join(env.outputDir, 'schemas', 'schemas.ts');
+        const content = readFileSync(bundlePath, 'utf-8');
+        expect(content).toContain("import * as z from 'zod/v4'");
+      } finally {
+        await env.cleanup();
+      }
+    },
+    GENERATION_TIMEOUT,
+  );
+
+  it(
+    'emits \'import { z } from "zod"\' when zodImportTarget is auto (single-file)',
+    async () => {
+      const env = await TestEnvironment.createTestEnv('zod-imports-auto-single-file');
+      try {
+        const config = {
+          ...ConfigGenerator.createBasicConfig(),
+          useMultipleFiles: false,
+          zodImportTarget: 'auto',
+        } as Partial<import('../src/config/parser').GeneratorConfig>;
+        const configPath = join(env.testDir, 'config.json');
+        writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+        const schema = PrismaSchemaGenerator.createBasicSchema({
+          outputPath: `${env.outputDir}/schemas`,
+          generatorOptions: { config: './config.json' },
+        });
+        writeFileSync(env.schemaPath, schema);
+        await env.runGeneration();
+
+        const bundlePath = join(env.outputDir, 'schemas', 'schemas.ts');
+        const content = readFileSync(bundlePath, 'utf-8');
+        expect(content).toContain("import { z } from 'zod'");
+      } finally {
+        await env.cleanup();
+      }
+    },
+    GENERATION_TIMEOUT,
+  );
+});

--- a/website/docs/recipes/zod-import-targets.md
+++ b/website/docs/recipes/zod-import-targets.md
@@ -1,0 +1,31 @@
+---
+id: zod-import-targets
+title: Zod import targets
+sidebar_label: Zod import targets
+---
+
+Control how generated schemas import Zod via the `zodImportTarget` config option.
+
+Install Zod in your app (peer dependency), then pick one of:
+
+- auto (default) or v3: import { z } from 'zod'
+- v4: import * as z from 'zod/v4'
+
+Notes
+- In single‑file bundles, a single Zod import is hoisted at the top.
+- This setting affects all generated files and variants.
+
+Quick recipes
+- Copy one of these into your config JSON:
+
+```json title="zod-generator.config.json"
+{ "zodImportTarget": "auto" }
+```
+
+```json title="zod-generator.config.json"
+{ "zodImportTarget": "v4" }
+```
+
+See also
+- Reference → Bytes and JSON
+- Configuration → Modes and Variants

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -43,6 +43,7 @@ const sidebars: SidebarsConfig = {
         'recipes/crud-only',
         'recipes/result-only',
         'recipes/input-only',
+        'recipes/zod-import-targets',
         'recipes/trpc-optimized',
         'recipes/single-file',
         'recipes/granular-per-model',


### PR DESCRIPTION
## Summary
Add `zodImportTarget` configuration to control how generated schemas import Zod. Supports:
- auto (default) or v3: `import { z } from 'zod'`
- v4: `import * as z from 'zod/v4'`

Applied consistently across multi-file output, single-file bundles, and JSON helpers.

## Motivation
- Allow users on Zod v4 to opt into the `zod/v4` subpath for better tree‑shaking and explicit versioning.
- Keep default output compatible with Zod v3 style while remaining valid on v4.
- Clarify dependency story by declaring `zod` as a peer dependency (`>=3.25.0 <5`).

## Changes
- Config
  - `src/config/parser.ts`: Add `zodImportTarget?: 'auto' | 'v3' | 'v4'`.
  - `src/config/schema.ts`: JSON schema validation (`enum`, default `auto`).
  - `CONFIG_REFERENCE.md`: New section “Zod import target”.
- Generator
  - `src/transformer.ts`: New `generateImportZodStatement()`; used everywhere Zod is imported.
  - `src/prisma-generator.ts`: Variants and pure models import Zod via transformer strategy.
  - `src/generators/model.ts`: Defer Zod import line to transformer; fix enum import path.
  - `src/utils/singleFileAggregator.ts`: Detect both `zod` and `zod/v4`; hoist a single import based on config.
- Recipes & Docs
  - `recipes/zod-imports/` with `README.md` and three JSON presets (`auto`, `v3`, `v4`).
  - `website/docs/recipes/zod-import-targets.md` and sidebar entry.
  - `recipes/README.md` updated/streamlined.
- Tests
  - `tests/zod-imports.test.ts` to validate single‑file bundles emit the correct import based on config.
  - `package.json` scripts: add `test:features:zodImports`.
- Dependencies
  - Declare `zod` as a peerDependency: `>=3.25.0 <5`.
  - Keep `zod` as a devDependency for running tests in this repo.

## Notes
- Bytes mapping and I/O behavior unchanged (still use `Uint8Array` for I/O; no `Buffer`).
- Minimal mode behavior unchanged.
- Import generation respects filtering; no unused imports emitted.

## Breaking Change
- The package now declares `zod` as a peer dependency (was previously implicit). Consumers must have `zod@^3 || ^4` installed. Default generated import remains `import { z } from 'zod'` (compatible with both v3 and v4). Opting into `zod/v4` is explicit via config.

## Verification
- Added targeted tests: `tests/zod-imports.test.ts` (single‑file, `v4` and `auto`).
- Manual smoke: run generation with `zodImportTarget: 'v4'` and confirm imports in the bundle and helpers.

## Checklist
- [x] Typecheck & lint locally
- [x] Targeted tests pass locally
- [x] Docs and recipes added
- [x] No Buffer usage introduced; Bytes mapping untouched

## Screenshots / Logs
N/A
