### PR TITLE
fix(variants): add missing .array() wrapper for enum arrays in variant schemas

### DIFF
--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -1865,7 +1865,12 @@ async function generateVariantSchemaContent(
 
       // Fallback to basic type generation
       const isEnum = field.kind === 'enum';
-      const base = isEnum ? `${field.type}Schema` : `z.${getZodTypeForField(field)}`;
+      let base = isEnum ? `${field.type}Schema` : `z.${getZodTypeForField(field)}`;
+
+      // Handle arrays - wrap with .array() if field is a list
+      if (field.isList) {
+        base = `${base}.array()`;
+      }
 
       // Apply consistent optional/nullable patterns based on Prisma behavior:
       // - Database stores NULL for optional fields (never undefined)


### PR DESCRIPTION
# Fix: Enum Arrays Missing .array() Wrapper in Variant Schemas

## Summary

- Fixed missing `.array()` wrapper for enum arrays in variant schemas (pure, input, result)
- Enum fields marked as arrays (`isList: true`) were generating incorrect validation schemas
- All three variant types now properly handle enum arrays

## Problem

When Prisma schema defines enum arrays like:
```prisma
model SalonSettings {
  enabledEmailTemplates SalonEmailTemplateType[]
}
```

The generated variant schemas were producing:
```typescript
enabledEmailTemplates: SalonEmailTemplateTypeSchema  // ❌ Missing .array()
```

Instead of the correct:
```typescript
enabledEmailTemplates: SalonEmailTemplateTypeSchema.array()  // ✅ Proper array validation
```

This caused validation failures when arrays were provided to the schemas.

## Fix

- Added array handling logic in `generateVariantSchemaContent()` function
- Applied `.array()` wrapper when `field.isList` is true for enum fields
- Fixed validation for all variant types: pure, input, and result schemas

## Test Plan

- [x] Verified enum arrays generate with `.array()` wrapper in all variant types
- [x] Confirmed array data validates successfully
- [x] Confirmed single enum values are properly rejected
- [x] Tested generation completes without errors
- [x] Verified no regression in non-array enum fields

## Validation

The fix ensures that:
1. **Array enum fields** generate `EnumSchema.array()` for proper validation
2. **Single enum fields** continue to generate `EnumSchema` (unchanged behavior)
3. **All variant types** (pure/input/result) handle enum arrays consistently
4. **Validation works correctly** - accepts arrays, rejects single values for array fields

Fixes #245