### PR TITLE
fix(generator): include unused enums in schema generation

### DIFF
--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -342,8 +342,6 @@ export async function generate(options: GeneratorOptions) {
     const mutableEnumTypes = {
       model: enumTypes.model ? [...enumTypes.model] : undefined,
       prisma: [...enumTypes.prisma],
-      // Add datamodel enums that might be missing from schema.enumTypes
-      datamodel: [...prismaClientDmmf.datamodel.enums],
     };
     const hiddenModels: string[] = [];
     const hiddenFields: string[] = [];
@@ -402,28 +400,20 @@ export async function generate(options: GeneratorOptions) {
     // Respect explicit emission controls for enums (default true)
     const emitEnums = generatorConfig.emit?.enums !== false;
     if (emitEnums) {
-      // Determine explicit enum emission (default true)
-      const emitEnums = generatorConfig.emit?.enums !== false;
-      if (emitEnums) {
-        // Include datamodel enums to capture unused enums that don't appear in schema.enumTypes
-        // Transform datamodel enums to match schema enum structure
-        const transformedDatamodelEnums = mutableEnumTypes.datamodel
-          .filter(
-            (datamodelEnum) =>
-              !mutableEnumTypes.model?.some((schemaEnum) => schemaEnum.name === datamodelEnum.name),
-          )
-          .map((datamodelEnum) => ({
-            name: datamodelEnum.name,
-            values: datamodelEnum.values.map((v) => v.name),
-          }));
+      // Include datamodel enums to capture unused enums that don't appear in schema.enumTypes
+      // Transform datamodel enums to match schema enum structure
+      const transformedDatamodelEnums = prismaClientDmmf.datamodel.enums
+        .filter(
+          (datamodelEnum) =>
+            !mutableEnumTypes.model?.some((schemaEnum) => schemaEnum.name === datamodelEnum.name),
+        )
+        .map((datamodelEnum) => ({
+          name: datamodelEnum.name,
+          values: datamodelEnum.values.map((v) => v.name),
+        }));
 
-        const allModelEnums = [...(mutableEnumTypes.model ?? []), ...transformedDatamodelEnums];
-        await generateEnumSchemas(mutableEnumTypes.prisma, allModelEnums);
-      } else {
-        logger.debug(
-          '[prisma-zod-generator] \u23ED\uFE0F  emit.enums=false (skipping enum schemas)',
-        );
-      }
+      const allModelEnums = [...(mutableEnumTypes.model ?? []), ...transformedDatamodelEnums];
+      await generateEnumSchemas(mutableEnumTypes.prisma, allModelEnums);
     } else {
       logger.debug('[prisma-zod-generator] ⏭️  emit.enums=false (skipping enum schemas)');
     }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -338,7 +338,6 @@ export async function generate(options: GeneratorOptions) {
     const enumTypes = prismaClientDmmf.schema.enumTypes;
     const models: DMMF.Model[] = [...prismaClientDmmf.datamodel.models];
 
-
     const mutableModelOperations = [...modelOperations];
     const mutableEnumTypes = {
       model: enumTypes.model ? [...enumTypes.model] : undefined,
@@ -409,16 +408,16 @@ export async function generate(options: GeneratorOptions) {
         // Include datamodel enums to capture unused enums that don't appear in schema.enumTypes
         // Transform datamodel enums to match schema enum structure
         const transformedDatamodelEnums = mutableEnumTypes.datamodel
-          .filter(datamodelEnum => !(mutableEnumTypes.model?.some(schemaEnum => schemaEnum.name === datamodelEnum.name)))
-          .map(datamodelEnum => ({
+          .filter(
+            (datamodelEnum) =>
+              !mutableEnumTypes.model?.some((schemaEnum) => schemaEnum.name === datamodelEnum.name),
+          )
+          .map((datamodelEnum) => ({
             name: datamodelEnum.name,
-            values: datamodelEnum.values.map(v => v.name)
+            values: datamodelEnum.values.map((v) => v.name),
           }));
 
-        const allModelEnums = [
-          ...(mutableEnumTypes.model ?? []),
-          ...transformedDatamodelEnums
-        ];
+        const allModelEnums = [...(mutableEnumTypes.model ?? []), ...transformedDatamodelEnums];
         await generateEnumSchemas(mutableEnumTypes.prisma, allModelEnums);
       } else {
         logger.debug(

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1021,14 +1021,19 @@ export default class Transformer {
    * Check if an enum schema should be generated based on enabled models
    */
   private isEnumSchemaEnabled(enumName: string): boolean {
-    // Extract model name from enum names like "PostScalarFieldEnum" -> "Post"
+    // Always generate user-defined enums and Prisma built-in enums
+    // Only filter model-specific generated enums based on model configuration
+
+    // Check if this is a model-specific enum (like PostScalarFieldEnum)
     const modelName = this.extractModelNameFromEnum(enumName);
 
     if (modelName) {
+      // This is a model-specific enum, check if the model is enabled
       return Transformer.isModelEnabled(modelName);
     }
 
-    // If we can't determine the model, generate the enum (default behavior)
+    // For all other enums (user-defined enums like Status, Role, and Prisma built-ins),
+    // always generate them regardless of model configuration
     return true;
   }
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1038,12 +1038,18 @@ export default class Transformer {
   }
 
   /**
+   * Shared regex patterns for model-specific enum detection
+   */
+  private static readonly modelEnumPatterns = [
+    /^(\w+)ScalarFieldEnum$/,
+    /^(\w+)OrderByRelevanceFieldEnum$/,
+  ];
+
+  /**
    * Extract model name from enum name
    */
   private extractModelNameFromEnum(enumName: string): string | null {
-    const patterns = [/^(\w+)ScalarFieldEnum$/, /^(\w+)OrderByRelevanceFieldEnum$/];
-
-    for (const pattern of patterns) {
+    for (const pattern of Transformer.modelEnumPatterns) {
       const match = enumName.match(pattern);
       if (match) {
         return match[1];
@@ -1058,21 +1064,15 @@ export default class Transformer {
    * For model-related enums, use Pascal case model names consistently
    */
   private normalizeEnumName(enumName: string): string | null {
-    // Handle ScalarFieldEnum patterns
-    const scalarFieldMatch = enumName.match(/^(.+)ScalarFieldEnum$/);
-    if (scalarFieldMatch) {
-      const modelName = scalarFieldMatch[1];
-      // Convert model name to Pascal case and rebuild enum name
-      const pascalModelName = this.getPascalCaseModelName(modelName);
-      return `${pascalModelName}ScalarFieldEnum`;
-    }
-
-    // Handle other enum patterns in the future if needed
-    const orderByRelevanceMatch = enumName.match(/^(.+)OrderByRelevanceFieldEnum$/);
-    if (orderByRelevanceMatch) {
-      const modelName = orderByRelevanceMatch[1];
-      const pascalModelName = this.getPascalCaseModelName(modelName);
-      return `${pascalModelName}OrderByRelevanceFieldEnum`;
+    // Use shared patterns to detect and normalize model-specific enums
+    for (const pattern of Transformer.modelEnumPatterns) {
+      const match = enumName.match(pattern);
+      if (match) {
+        const modelName = match[1];
+        const pascalModelName = this.getPascalCaseModelName(modelName);
+        // Rebuild enum name with normalized model name
+        return enumName.replace(modelName, pascalModelName);
+      }
     }
 
     // Return null for non-model-related enums to use original name


### PR DESCRIPTION
## Summary

Fixes issue where user-defined enums that aren't referenced in any model were not being generated as Zod schemas.

## Problem

When defining enums in a Prisma schema that are not used by any model field, the prisma-zod-generator would skip generating Zod schemas for these enums. This happened because:

- Prisma's DMMF (Data Model Meta Format) only includes referenced enums in `schema.enumTypes` 
- Unused enums exist in `datamodel.enums` but were not being processed
- The generator was only looking at `schema.enumTypes` for enum generation

## Solution

- Enhanced enum collection to include unused enums from `datamodel.enums`
- Transform datamodel enum structure to match schema enum format
- Improved enum filtering logic to distinguish between:
  - Model-specific enums (like `PostScalarFieldEnum`) - filtered by model configuration
  - Standalone enums (like `Status`, `Role`) - always generated regardless of model config

## Test Plan

- [x] Added test enum `Status` with values `['added', 'active', 'removed']` to schema
- [x] Verified enum is not referenced by any model
- [x] Confirmed enum schema is now generated correctly
- [x] Verified existing functionality remains intact
- [x] Type checking passes
- [x] Formatting and linting compliant

## Changes

- `src/prisma-generator.ts`: Enhanced enum collection to include datamodel enums
- `src/transformer.ts`: Improved enum filtering logic with better documentation

Fixes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically generates enums defined in the data model even if they aren’t listed in the schema’s enum types, ensuring all relevant enums are available.

* **Bug Fixes**
  * Model-specific enums now consistently respect model enablement, preventing generation for disabled models.
  * Enum generation behavior preserved while correctly including previously missed datamodel enums; logging and emission gating remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->