### PR TITLE
fix(variants): prevent double .array() in variant generation

### DIFF
--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -1875,7 +1875,10 @@ async function generateVariantSchemaContent(
 
       // Handle arrays - wrap with .array() if field is a list
       if (field.isList) {
-        base = `${base}.array()`;
+        // Avoid double array wrapping by checking if already wrapped
+        if (!base.includes('z.array(') && !base.includes('.array()')) {
+          base = `${base}.array()`;
+        }
       }
 
       // Apply consistent optional/nullable patterns based on Prisma behavior:


### PR DESCRIPTION
### Description

Fixes issue 252 by checking if field is already array-wrapped before adding .array() modifier in variant generation. Adds comprehensive test case to prevent regression.

### References

https://github.com/omar-dulaimi/prisma-zod-generator/issues/252

### Checklist

- [x] I ran tests locally and they pass
- [x] I updated docs or comments where relevant
- [x] I added or updated tests for new behavior
- [x] I’ve considered performance and backward compatibility
- [x] I’ve searched for related issues/PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-wrapped arrays in generated schemas for list fields, ensuring a single array wrapper is used. This prevents invalid patterns (e.g., nested .array() calls) and produces correct array types across all variants.

* **Tests**
  * Added comprehensive regression tests to validate correct array handling for list fields across pure, input, and result variants.
  * Tests assert the presence of a single array wrapper and the absence of any double .array() patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->