### PR TITLE
fix(parsers): do not quote arrow/function params in @zod

### DIFF
--- a/src/parsers/zod-comments.ts
+++ b/src/parsers/zod-comments.ts
@@ -2109,9 +2109,17 @@ function formatSingleParameter(param: unknown): string {
 
   if (typeof param === 'string') {
     // Check if it's a complex expression that shouldn't be quoted
-    // Complex expressions include: new Date(), RegExp(), function calls, or dotted calls like z.string()
-    if (param.match(/^(new\s+\w+\(|RegExp\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\()/)) {
-      return param; // Return complex expressions as-is
+    // Complex expressions include: new Date(), RegExp(), function calls,
+    // arrow functions (value => ... or (value) => ...), async arrows, or dotted calls like z.string()
+    const isDottedOrCtorCall = /^(new\s+\w+\(|RegExp\(|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\()/;
+    const isFunctionKeyword = /^\s*function\b/;
+    const isArrowFunction = /^\s*(?:async\s+)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/;
+    if (
+      isDottedOrCtorCall.test(param) ||
+      isFunctionKeyword.test(param) ||
+      isArrowFunction.test(param)
+    ) {
+      return param; // Return complex/functional expressions as-is
     }
     // Prefer double quotes for URL-like strings (e.g., https://) to match snapshots
     if (/^https?:\/\//i.test(param)) {


### PR DESCRIPTION
Summary
- Prevent quoting of function expressions in @zod annotation parameters so generated Zod chains pass real functions to .transform()/.refine().

Motivation/Context
- Running `pnpm gen-example` produced TS errors where `.transform('(value) => Number(value)')` and `.refine('(value) => value > 0', {...})` were emitted as strings instead of functions, breaking Zod typing and runtime behavior.
- This PR fixes the directive parsing so arrow/function expressions are treated as raw code.

Changes
- src/parsers/zod-comments.ts: formatSingleParameter
  - Detect arrow functions (sync/async), function expressions, and dotted/call expressions
  - Return them unquoted as raw expressions
- Keeps prior handling for constructor/dotted calls (e.g., `z.string()`, `new Date()`).

Testing/Validation
- Ran `pnpm gen-example`: generation succeeds; `tsc --noEmit` clean.
- Ran quality gates: `pnpm typecheck`, `pnpm lint`, `pnpm format`.
- Ran default feature test suite: all tests passed (see CI logs locally: 19 files, 232 tests passed).

Breaking changes
- None. Behavior is more correct for @zod annotations using functional params.

Related issues
- Closes #292

Checklist
- [x] Conventional Commit with clear scope
- [x] Focused change with tests passing locally
- [x] No unrelated changes
- [x] PR body includes context, validation, and closure reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves formatting of string parameters in generated Zod code by preserving complex expressions (e.g., arrow/async functions, function keyword forms, and constructor/call chains) without adding quotes.
  * Maintains correct quoting for plain URL-like strings while avoiding over-quoting of functional expressions.

* **Refactor**
  * Enhances expression detection logic for more reliable handling of complex parameter inputs, reducing false positives and improving overall formatting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->