### PR TITLE
fix(transformer): lazy include references for findMany

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -3352,8 +3352,11 @@ ${helperCode}
             target1 === 'v4'
               ? `get select(){ return ${selectFieldReference}; },`
               : `select: ${selectFieldReference},`;
-          const includeFieldRef1 =
-            includeValueExpr || includeZodSchemaLineLazy.replace('include: ', '').replace(',', '');
+          const includeFieldRef1 = this.resolveIncludeFieldReference(
+            includeValueExpr,
+            includeZodSchemaLineLazy,
+            target1 === 'v4',
+          );
           const includeField = includeFieldRef1
             ? target1 === 'v4'
               ? `get include(){ return ${includeFieldRef1}; },`
@@ -3425,8 +3428,11 @@ ${helperCode}
             target2 === 'v4'
               ? `get select(){ return ${selectFieldReference}; },`
               : `select: ${selectFieldReference},`;
-          const includeFieldRef2 =
-            includeValueExpr || includeZodSchemaLineLazy.replace('include: ', '').replace(',', '');
+          const includeFieldRef2 = this.resolveIncludeFieldReference(
+            includeValueExpr,
+            includeZodSchemaLineLazy,
+            target2 === 'v4',
+          );
           const includeField = includeFieldRef2
             ? target2 === 'v4'
               ? `get include(){ return ${includeFieldRef2}; },`
@@ -3502,13 +3508,11 @@ ${helperCode}
               ? `get select(){ return ${selectFieldReference}; },`
               : `select: ${selectFieldReference},`;
 
-          const includeFieldRef3 = includeValueExpr
-            ? target3 === 'v4'
-              ? includeValueExpr
-              : includeZodSchemaLineLazy
-                ? includeZodSchemaLineLazy.replace('include: ', '').replace(',', '').trim()
-                : includeValueExpr
-            : '';
+          const includeFieldRef3 = this.resolveIncludeFieldReference(
+            includeValueExpr,
+            includeZodSchemaLineLazy,
+            target3 === 'v4',
+          );
           const includeField = includeFieldRef3
             ? target3 === 'v4'
               ? `get include(){ return ${includeFieldRef3}; },`
@@ -4688,6 +4692,26 @@ ${helperCode}
       selectValueExpr,
       includeValueExpr,
     };
+  }
+
+  private resolveIncludeFieldReference(
+    includeValueExpr?: string,
+    includeZodSchemaLineLazy?: string,
+    isV4Target = false,
+  ): string {
+    if (!includeValueExpr && !includeZodSchemaLineLazy) {
+      return '';
+    }
+
+    if (isV4Target) {
+      return includeValueExpr ?? '';
+    }
+
+    if (includeZodSchemaLineLazy) {
+      return includeZodSchemaLineLazy.replace('include: ', '').replace(',', '').trim();
+    }
+
+    return includeValueExpr ?? '';
   }
 
   resolveOrderByWithRelationImportAndZodSchemaLine(model: PrismaDMMF.Model) {


### PR DESCRIPTION
## Summary
- add lazy include references for findMany schemas when targeting non-Zod v4 builds to avoid premature evaluation
- verified generator output end-to-end inside the linked repro app to ensure the circular include error no longer occurs

## Motivation / Context
Fixes #332 where generated findMany schemas referenced `CompanyIncludeObjectSchema` before it finished initializing, causing runtime failures in downstream apps using the published package.

## Changes
- update `Transformer` include field generation to emit `z.lazy` wrappers for include schemas unless the Zod v4 getter form is used
- rebuild the generator and validate against the public bug reproduction to confirm the circular dependency is resolved


## Breaking Changes
- none

## Related Issues
- Closes #332

## Checklist
- [x] Changes documented in this PR body
- [ ] `pnpm test` (skipped intentionally per request)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and unified handling of include fields for queries, fixing edge cases so include expressions are emitted consistently and reliably across targets.
* **Refactor**
  * Centralized include-resolution logic to simplify control flow and ensure predictable behavior when multiple include representations are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->