### PR TITLE
Wrap decimal defaults in new Prisma.Decimal(value)

### DIFF
--- a/src/generators/model.ts
+++ b/src/generators/model.ts
@@ -1448,8 +1448,8 @@ export class PrismaTypeMapper {
 
         // Handle decimal defaults
         const mode = this.config.decimalMode || 'decimal';
-        if(field.type === 'Decimal' && mode === 'decimal') {
-          literalValue = `new Prisma.Decimal(${literalValue})`
+        if (field.type === 'Decimal' && mode === 'decimal') {
+          literalValue = `new Prisma.Decimal(${literalValue})`;
         }
         // Defer duplicate default check to wrapper stage
         result.zodModifier += `.default(${literalValue})`;

--- a/tests/pure-models.test.ts
+++ b/tests/pure-models.test.ts
@@ -441,17 +441,17 @@ generator zod {
 
 model User {
   id    Int    @id @default(autoincrement())
-  
+
   /**
    * The user's email address
    * Used for authentication and notifications
    * @example "john.doe@example.com"
    */
   email String @unique
-  
+
   /// Display name for the user
   name  String?
-  
+
   /**
    * User's age in years
    * Must be between 0 and 120
@@ -459,7 +459,7 @@ model User {
    * @maximum 120
    */
   age   Int?
-  
+
   /// Whether the user account is active
   isActive Boolean @default(true)
 }
@@ -531,7 +531,7 @@ generator zod {
 
 model Product {
   id Int @id @default(autoincrement())
-  
+
   /**
    * Product name
    * @description The display name of the product
@@ -540,7 +540,7 @@ model Product {
    * @maxLength 100
    */
   name String
-  
+
   /**
    * Product price in USD
    * @description The price of the product in US dollars
@@ -550,10 +550,10 @@ model Product {
    * @multipleOf 0.01
    */
   price Float
-  
+
   /// @deprecated Use 'isAvailable' instead
   inStock Boolean @default(true)
-  
+
   /**
    * Product availability status
    * @since 2.0.0
@@ -623,25 +623,25 @@ generator zod {
 
 model ComplexTypes {
   id          Int      @id @default(autoincrement())
-  
+
   // Decimal handling
   price       Decimal  @db.Decimal(10, 2)
   weight      Decimal? @db.Decimal(8, 3)
   height      Decimal? @db.Decimal(8, 3) @default(1)
-  
+
   // JSON handling
   settings    Json
   metadata    Json?
-  
+
   // Bytes handling
   avatar      Bytes?
   document    Bytes
-  
+
   // DateTime handling
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   scheduledAt DateTime?
-  
+
   // BigInt handling
   bigNumber   BigInt
   bigOptional BigInt?
@@ -666,7 +666,7 @@ model ComplexTypes {
               /weight:\s*z\.instanceof\(Prisma\.Decimal[\s\S]*?\)[\s\S]*?\.optional\(\)/,
             );
             expect(content).toMatch(
-              /height:\s*z\.instanceof\(Prisma\.Decimal[\s\S]*?\)[\s\S]*?\.optional\(new Prisma.Decimal\(1\)\)/,
+              /height:\s*z\.instanceof\(Prisma\.Decimal[\s\S]*?\)[\s\S]*?\.default\(new Prisma.Decimal\(1\)\)[\s\S]*?\.optional\(\)/,
             );
 
             // JSON fields - should be z.unknown() or z.record()
@@ -1137,29 +1137,29 @@ generator zod {
 
 model User {
   id Int @id @default(autoincrement())
-  
+
   /**
    * User's email address
    * @example "user@example.com"
    */
   email String @unique /// @zod.email().toLowerCase()
-  
+
   /**
    * User's full name
    * @minLength 2
    * @maxLength 50
    */
   name String? /// @zod.min(2).max(50).trim()
-  
+
   /// User's age in years
   age Int? /// @zod.min(0).max(120)
-  
+
   /// Whether the user is active
   isActive Boolean @default(true) /// @zod.default(true)
-  
+
   /// User registration date
   createdAt DateTime @default(now())
-  
+
   /// User preferences stored as JSON
   preferences Json? /// @zod.record(z.string()).optional()
 }


### PR DESCRIPTION
### Description

prisma-zod-generator when used with decimals and defaults generates code like
```typescript
export const model = z.object({
  quantity: z.instanceof(Prisma.Decimal, {
    message: "Field 'quantity' must be a Decimal. Location: ['Models', 'model']",
  }).default(1),
});
```
But this fails typechecking as the default value is not the expected type (Prisma.Decimal)
This change now wraps the value in a `new Prisma.Decimal(${value})` so the code generates like
```typescript
export const model = z.object({
  quantity: z.instanceof(Prisma.Decimal, {
    message: "Field 'quantity' must be a Decimal. Location: ['Models', 'model']",
  }).default(new Prisma.Decimal(1)),
});
```

### Checklist

- [x] I ran tests locally and they pass
- [x] I updated docs or comments where relevant
- [x] I added or updated tests for new behavior
- [x] I’ve considered performance and backward compatibility
- [x] I’ve searched for related issues/PRs

### Sponsor Note (optional)

If your organization relies on this project, please consider sponsoring to support ongoing maintenance and new features: https://github.com/sponsors/omar-dulaimi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of default values for decimal fields to ensure proper formatting in generated schemas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->