### PR TITLE
fix: use options.dmmf to avoid version mismatch with @prisma/internals

### DIFF
--- a/src/cli/pzg-pro-generator.ts
+++ b/src/cli/pzg-pro-generator.ts
@@ -90,7 +90,7 @@ export async function generateProFeatures(options: GeneratorOptions): Promise<vo
       throw new Error('prisma-client-js or prisma-client generator is required');
     }
 
-    const dmmf = await getDMMF({
+    const dmmf = options.dmmf ?? await getDMMF({
       datamodel: options.datamodel,
       previewFeatures: prismaClientGeneratorConfig.previewFeatures,
     });

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -86,7 +86,7 @@ export async function generate(options: GeneratorOptions) {
 
     maybeWarnOnUnsupportedPrismaVersion(options);
 
-    const prismaClientDmmf = await getDMMF({
+    const prismaClientDmmf = options.dmmf ?? await getDMMF({
       datamodel: options.datamodel,
       previewFeatures: prismaClientGeneratorConfig?.previewFeatures,
     });


### PR DESCRIPTION
## Problem

When using Prisma preview features like `partialIndexes` (introduced in newer Prisma versions), the generator silently fails to produce any output. The root cause is that the generator re-parses the schema via `getDMMF()` from its own `@prisma/internals` dependency, which may resolve to a different version than the user's Prisma CLI. If the user's schema uses features that the resolved version doesn't understand, the parse fails, but since the error is caught by the top-level `catch` block, Prisma still reports success with a green checkmark.

For example, with `partialIndexes` enabled and `@@unique(..., where: raw(...))` in the schema, `@prisma/internals@7.0.0` (resolved from `^7.0.0`) produces 6 validation errors ("No such argument", "preview feature not known"), but the user only sees:

```
✔ Generated Prisma Zod Generator to ./dist/zod in 267ms
```

No files are actually written.

This is particularly common with pnpm, where strict dependency isolation means the generator's `@prisma/internals` resolves independently from the Prisma CLI's version.

## Fix

Prisma already passes the fully-parsed DMMF to generators via `options.dmmf`. This DMMF is parsed by the user's actual Prisma CLI version, so it always supports whatever features their schema uses. This PR changes both `prisma-generator.ts` and `pzg-pro-generator.ts` to prefer `options.dmmf` when available, falling back to the existing `getDMMF()` call for safety:

```typescript
const prismaClientDmmf = options.dmmf ?? await getDMMF({ ... });
```

It's possible the `getDMMF()` fallback could be removed entirely since `options.dmmf` has been part of the Prisma generator protocol for a long time, but I kept it as a fallback since I'm not sure if there was a specific reason it was originally preferred. Happy to remove it if you think that's cleaner.

## Testing

Verified against a real-world monorepo with Prisma 7.4.0, `partialIndexes` preview feature, and 5 models using `@@unique(..., where: raw(...))`. Before the fix, `dist/zod/` was empty. After the fix, the generator produces the expected output.